### PR TITLE
added ":Denite filetype" to change the filetype of current buffer

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -261,14 +261,19 @@ file_rec	Gather files recursive and nominates all file names under the
 		command		 default get files command
 				(default is used "find" command)
 
-						*denite-source-jump_point*
-jump_point		
+						*denite-source-filetype*
+filetype	Gather filetypes and change the filetype of the current
+		buffer.
 
 						*denite-source-grep*
 grep		Gather grep results and nominates them.
 
+						*denite-source-jump_point*
+jump_point
+
 						*denite-source-line*
-line		
+line
+
 
 ==============================================================================
 KINDS							*denite-kinds*

--- a/rplugin/python3/denite/source/filetype.py
+++ b/rplugin/python3/denite/source/filetype.py
@@ -1,0 +1,36 @@
+# ============================================================================
+# FILE: filetype.py
+# AUTHOR: Prabir Shrestha <mail at prabir.me>
+# License: MIT license
+# ============================================================================
+
+from .base import Base
+from os import path, listdir
+
+
+class Source(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'filetype'
+        self.kind = 'command'
+
+    def gather_candidates(self, context):
+        # since self.vim.list_runtime_paths() does not work in vim 8
+        # use eval instead
+        rtps = self.vim.eval('&runtimepath').split(',')
+        filetypes = {}
+
+        for rtp in rtps:
+            syntax_dir = path.join(rtp, 'syntax')
+            if path.exists(syntax_dir):
+                for file in listdir(syntax_dir):
+                    if file.endswith('.vim'):
+                        filetype = path.splitext(file)[0]
+                        filetypes[filetype] = {
+                            'word': filetype,
+                            'action__command': 'set filetype=' + filetype
+                        }
+
+        return sorted(filetypes.values(), key=lambda value: value['word'])


### PR DESCRIPTION
Works in neovim as well as in vim8.

Currently only shows the list. Ideally I would like to set the default action to change the filetype of the buffer. But reading the docs I see **denite-actions are not implemented**. Are there any plans to implement one soon?

neovim:
![image](https://cloud.githubusercontent.com/assets/287744/18611540/2e919176-7cf1-11e6-9269-9cf4b5205c88.png)

vim8:
![image](https://cloud.githubusercontent.com/assets/287744/18611543/45dbdb48-7cf1-11e6-87db-09402084c606.png)

Not a python dev so feel free to suggest better way to write it if there is one.