### PR TITLE
Grep improves

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -96,6 +96,17 @@ EXAMPLES						*denite-examples*
 		\ ]
 
 	call denite#custom#var('menu', 'menus', s:menus)
+
+	" Ack command on grep source, doesn't need some vars defaults are 
+	" enough
+	call denite#custom#var('grep', 'command', ['ack'])
+	call denite#custom#var('grep', 'recursive_opts', [])
+	call denite#custom#var('grep', 'final_opts', [])
+	call denite#custom#var('grep', 'separator', [])
+	call denite#custom#var('grep', 'default_opts',
+			\ ['--ackrc '.$HOME.'/.ackrc', '-H',
+			\ '--nopager', '--nocolor', '--nogroup', '--column'])
+
 <
 
 ==============================================================================
@@ -290,7 +301,7 @@ filetype	Gather filetypes and change the filetype of the current
 						*denite-source-grep*
 grep		Gather grep results and nominates them.
 		The source executes ["command", "default_opts",
-		"recursive_opts", {arguments}, "separator", {directory}]
+		"recursive_opts", {arguments}, "separator", "final_opts"]
 		command line.
 		Note: The command result must be "path:linenr:text" pattern.
 
@@ -307,6 +318,8 @@ grep		Gather grep results and nominates them.
 				(default: ["-r"])
 		separator	the argument separator
 				(default: ["--"])
+		final_opts	the final arguments
+				(default: ["."] path to search argument)
 
 
 						*denite-source-jump_point*

--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -22,6 +22,7 @@ class Source(Base):
             'default_opts': ['-inH'],
             'recursive_opts': ['-r'],
             'separator': ['--'],
+            'final_opts': ['.'],
         }
         self.__proc = None
 
@@ -52,7 +53,8 @@ class Source(Base):
         commands += context['__arguments']
         commands += self.vars['separator']
         commands += [context['__input']]
-        commands += [context['__directory']]
+        commands += self.vars['final_opts']
+
         self.__proc = subprocess.Popen(commands,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,

--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -70,6 +70,7 @@ class Source(Base):
             return []
 
         candidates = []
+
         for line in outs.decode('utf-8').split('\n'):
             result = parse_jump_line(self.vim, line)
             if result:


### PR DESCRIPTION
This allows to use shell environment variables and configs.

Searches under current work directory and with this changes I can use ack:

```vim
call denite#custom#var('grep', 'command', ['ack'])
call denite#custom#var('grep', 'recursive_opts', [])
call denite#custom#var('grep', 'separator', [])
call denite#custom#var('grep', 'final_opts', [])
call denite#custom#var('grep', 'default_opts', 
     \ ['-s', '-H', '--nopager', '--nocolor', '--nogroup', '--column'])
```

```vim
:Denite grep

Pattern: --[ack-type] React [subdirectory or any other extra param ]
```