### PR TITLE
Improve grep source

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -104,7 +104,7 @@ EXAMPLES						*denite-examples*
 	call denite#custom#var('grep', 'final_opts', [])
 	call denite#custom#var('grep', 'separator', [])
 	call denite#custom#var('grep', 'default_opts',
-			\ ['--ackrc '.$HOME.'/.ackrc', '-H',
+			\ ['--ackrc', $HOME.'/.ackrc', '-H',
 			\ '--nopager', '--nocolor', '--nogroup', '--column'])
 
 <

--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -8,6 +8,7 @@ from .base import Base
 from denite.util import parse_jump_line
 import subprocess
 import os
+import shlex
 
 
 class Source(Base):
@@ -52,7 +53,7 @@ class Source(Base):
         commands += self.vars['recursive_opts']
         commands += context['__arguments']
         commands += self.vars['separator']
-        commands += [context['__input']]
+        commands += shlex.split(context['__input'])
         commands += self.vars['final_opts']
 
         self.__proc = subprocess.Popen(commands,
@@ -64,7 +65,8 @@ class Source(Base):
 
     def __async_gather_candidates(self, context):
         try:
-            outs, errs = self.__proc.communicate(timeout=0.1)
+            outs, errs = self.__proc.communicate(timeout=2)
+            self.debug(errs)
             context['is_async'] = False
         except subprocess.TimeoutExpired:
             return []

--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -66,7 +66,6 @@ class Source(Base):
     def __async_gather_candidates(self, context):
         try:
             outs, errs = self.__proc.communicate(timeout=2)
-            self.debug(errs)
             context['is_async'] = False
         except subprocess.TimeoutExpired:
             return []


### PR DESCRIPTION
- Update doc to enable ackrc in config
- Input parsed by shlex to use all the power of grep-like programs,
  allow productivity when needs to add more arguments to default_opts
  and :Denite grep [arguments].
- Extend timeout to 2 seconds instead 0.1 (no results with large project),
  we can use 2 seconds because now is async.