### PR TITLE
Disable relativenumber to completely remove numbers

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -71,6 +71,7 @@ class Default(object):
         self.__window_options['cursorline'] = True
         self.__window_options['colorcolumn'] = ''
         self.__window_options['number'] = False
+        self.__window_options['relativenumber'] = False
         self.__window_options['foldenable'] = False
         self.__window_options['foldcolumn'] = 0
 


### PR DESCRIPTION
# Problem
If a window has `relativenumber` enabled, denite's window displays numbers. Screenshot: 
![image](https://cloud.githubusercontent.com/assets/147918/19571080/5e7baf24-9705-11e6-9716-d33f21834d2e.png)

# Expected
Denite's window should have numbers disabled, probably custom icons are planned.
