### PR TITLE
Passed escaped regexp to syntax command

### DIFF
--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -70,7 +70,7 @@ class Source(Base):
             'syntax region ' + self.syntax_name + ' start=// end=/$/ '
             'contains=deniteSource_grepHeader,deniteMatched contained')
         self.vim.command(
-            'syntax match deniteGrepInput /%s/ ' % input_str +
+            'syntax match deniteGrepInput /%s/ ' % input_str.replace('/', '\/') +
             'contained containedin=' + self.syntax_name)
         self.vim.command('highlight default link deniteGrepInput Function')
 


### PR DESCRIPTION
When I run `Denite grep` with pattern included slash (e.g `aaa/bbb`), Error such as following has occured.

so, I have worked around by this fix. 

```
Error detected while processing function denite#helper#call_denite[12]..denite#start[15].._denite_start:
line    1:
[denite] Traceback (most recent call last):
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/pocari/denite.nvim/rplugin/python3/denite/ui/default.py", line 70, in start
[denite]     self.init_buffer()
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/pocari/denite.nvim/rplugin/python3/denite/ui/default.py", line 129, in init_buffer
[denite]     self.__init_syntax()
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/pocari/denite.nvim/rplugin/python3/denite/ui/default.py", line 164, in __init_syntax
[denite]     source.highlight_syntax()
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/pocari/denite.nvim/rplugin/python3/denite/source/grep.py", line 74, in highlight_syntax
[denite]     'contained containedin=' + self.syntax_name)
[denite]   File "/usr/local/lib/python3.5/site-packages/neovim/api/nvim.py", line 216, in command
[denite]     return self.request('vim_command', string, **kwargs)
[denite]   File "/usr/local/lib/python3.5/site-packages/neovim/api/nvim.py", line 129, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/usr/local/lib/python3.5/site-packages/neovim/msgpack_rpc/session.py", line 98, in request
[denite]     raise self.error_wrapper(err)
[denite] neovim.api.nvim.NvimError: b'Vim(syntax):E402: Garbage after pattern: /dotfiles/_vimrc/ contained containedin=deniteSource_grep'
[denite] An error has occurred. Please execute :messages command.
```