### PR TITLE
Fix a syntax error of example in document

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -140,7 +140,7 @@ EXAMPLES						*denite-examples*
 	call denite#custom#var('grep', 'final_opts', [])
 	call denite#custom#var('grep', 'separator', ['--'])
 	call denite#custom#var('grep', 'default_opts',
-			\ ['--vimgrep', '--no-heading']
+			\ ['--vimgrep', '--no-heading'])
 
 	call denite#custom#source('file_mru', 'converters',
 	      \ ['converter_relative_word'])


### PR DESCRIPTION
Thanks for the great plugin!

I've added a missing `)`