### PR TITLE
Add scrolling window/page feature, and `scroll` context setting

### DIFF
--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -85,6 +85,10 @@ function! denite#init#_variables() abort "{{{
         \ "i": 'enter_mode:insert',
         \ "j": 'move_to_next_line',
         \ "k": 'move_to_prev_line',
+        \ "<C-d>": 'scroll_window_downwards',
+        \ "<C-u>": 'scroll_window_upwards',
+        \ "<C-f>": 'scroll_page_forwards',
+        \ "<C-b>": 'scroll_page_backwards',
         \ "p": 'do_action:preview',
         \ "q": 'quit',
         \}
@@ -125,6 +129,7 @@ function! denite#init#_user_options() abort "{{{
         \ 'resume': v:false,
         \ 'statusline': v:true,
         \ 'winheight': 20,
+        \ 'scroll': 0,
         \}
 endfunction"}}}
 

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -252,6 +252,22 @@ move_to_next_line
 move_to_prev_line
 		Move to previous line.
 
+					*denite-map-scroll_window_downwards*
+scroll_window_downwards
+		Scroll the window downwards.
+
+					*denite-map-scroll_window_upwards*
+scroll_window_upwards
+		Scroll the window upwards.
+
+					*denite-map-scroll_page_forwards*
+scroll_page_forwards
+		Scroll the page forwards.
+
+					*denite-map-scroll_page_backwards*
+scroll_page_backwards
+		Scroll the page backwards.
+
 				*denite-map-paste_from_register*
 paste_from_register
 		Paste the text from unnamed register.
@@ -304,6 +320,10 @@ All mode mappings.
 i		enter_mode:insert
 j		move_to_next_line
 k		move_to_prev_line
+<C-d>		scroll_window_downwards
+<C-u>		scroll_window_upwards
+<C-f>		scroll_page_forwards
+<C-b>		scroll_page_backwards
 p		do_action:preview
 q		quit
 <Tab>		choose_action

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -39,6 +39,7 @@ class Default(object):
         self.__winsaveview = {}
         self.__initialized = False
         self.__winheight = 0
+        self.__scroll = 0
         self.__is_multi = False
         self.__matched_pattern = ''
         self.__statusline_sources = ''
@@ -91,6 +92,9 @@ class Default(object):
         self.__prev_tabpages = self.__vim.call('tabpagebuflist')
         self.__winrestcmd = self.__vim.call('winrestcmd')
         self.__winsaveview = self.__vim.call('winsaveview')
+        self.__scroll = int(self.__context['scroll'])
+        if self.__scroll == 0:
+            self.__scroll = round(self.__winheight / 2)
 
         if self.__winid > 0 and self.__vim.call(
                 'win_gotoid', self.__winid):
@@ -434,6 +438,39 @@ class Default(object):
             self.__win_cursor -= 1
         elif self.__cursor >= 1:
             self.__cursor -= 1
+        else:
+            return
+        self.update_buffer()
+
+    def scroll_window_upwards(self):
+        self.scroll_up(self.__scroll)
+
+    def scroll_window_downwards(self):
+        self.scroll_down(self.__scroll)
+
+    def scroll_page_backwards(self):
+        self.scroll_up(self.__winheight - 1)
+
+    def scroll_page_forwards(self):
+        self.scroll_down(self.__winheight - 1)
+
+    def scroll_down(self, scroll):
+        if (self.__win_cursor < self.__candidates_len and
+                self.__win_cursor < self.__winheight):
+            self.__win_cursor = min(self.__win_cursor + scroll,
+                                    self.__candidates_len, self.__winheight)
+        elif self.__win_cursor + self.__cursor < self.__candidates_len:
+            self.__cursor = min(self.__cursor + scroll,
+                                self.__candidates_len - self.__win_cursor)
+        else:
+            return
+        self.update_buffer()
+
+    def scroll_up(self, scroll):
+        if self.__win_cursor > 1:
+            self.__win_cursor = max(self.__win_cursor - scroll, 1)
+        elif self.__cursor > 0:
+            self.__cursor = max(self.__cursor - scroll, 0)
         else:
             return
         self.update_buffer()


### PR DESCRIPTION
- Context option: `scroll`, when default or `0`, half of `winheight`.
- Scroll a window: Move up/downwards using `scroll` context setting.
- Scroll a page:  Move for/backwards using `winheight` context setting.
- New _normal-mode_ key-mappings:
  - `<C-d>` and `<C-u>` for _window_ scrolling
  - `<C-f>` and `<C-b>` for _page_ scrolling
