### PR TITLE
Add split and vsplit action for file kind

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -665,6 +665,12 @@ file		An interface to jump to the file position.
 			tabopen
 				Open the file in the next tab.
 
+			split
+				open the file with 'split'.
+
+			vsplit
+				open the file with 'vsplit'.
+
 						*denite-kind-word*
 word		An interface to paste the text.
 

--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -34,6 +34,14 @@ class Kind(Base):
                 'denite#util#execute_path', 'buffer', path)
         self.__jump(context, target)
 
+    def action_split(self, context):
+        self.vim.command('split')
+        self.action_open(context)
+
+    def action_vsplit(self, context):
+        self.vim.command('vsplit')
+        self.action_open(context)
+
     def action_preview(self, context):
         target = context['targets'][0]
         path = target['action__path'].replace('/./', '/')


### PR DESCRIPTION
#### 概要
file kind に split action と vsplit action を追加しました。
想定マッピングとしては v=vsplit, s=split です。

#### 仕様
- 選択された file kind の候補を denite.nvim を起動したバッファにおいて vsplit/split して開きます。
- 今後、複数候補選択が入った場合には、選択候補すべてを開き、最後の候補に jump する想定です。

#### 迷ったところ
- 今後、`do_vim_function:MyAwesomeFunction` のような機能を設けて、本体で機能を持たないという思想だったらすいません。
- doc の `(default)` は意味を間違っているかもなので、その場合は、preview 側合わせて修正します。