### PR TITLE
Jump between sources

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -252,6 +252,14 @@ move_to_next_line
 move_to_prev_line
 		Move to previous line.
 
+						*denite-map-jump_to_next_source*
+jump_to_next_source
+		Jump to the first candidate of the next source.
+
+						*denite-map-jump_to_prev_source*
+jump_to_prev_source
+		Jump to the first candidate of the previous source.
+
 					*denite-map-scroll_window_downwards*
 scroll_window_downwards
 		Scroll the window downwards.

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -240,6 +240,14 @@ input_command_line
 		Input characters by Vim command line.
 		You can input multibyte characters.
 
+						*denite-map-jump_to_next_source*
+jump_to_next_source
+		Jump to the first candidate of the next source.
+
+						*denite-map-jump_to_prev_source*
+jump_to_prev_source
+		Jump to the first candidate of the previous source.
+
 							*denite-map-leave_mode*
 leave_mode
 		Return to the previous mode or close current Denite buffer.
@@ -251,14 +259,6 @@ move_to_next_line
 						*denite-map-move_to_prev_line*
 move_to_prev_line
 		Move to previous line.
-
-						*denite-map-jump_to_next_source*
-jump_to_next_source
-		Jump to the first candidate of the next source.
-
-						*denite-map-jump_to_prev_source*
-jump_to_prev_source
-		Jump to the first candidate of the previous source.
 
 					*denite-map-scroll_window_downwards*
 scroll_window_downwards

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -496,21 +496,21 @@ class Default(object):
         if len(self.__context['sources']) == 1:
             return
 
-        current_line = self.__cursor + self.__win_cursor - 1
-        forward_candidates = self.__candidates[current_line:]
+        current_index = self.__cursor + self.__win_cursor - 1
+        forward_candidates = self.__candidates[current_index:]
         forward_sources = groupby(
             forward_candidates,
             lambda candidate: candidate['source']
         )
         forward_times = len(list(next(forward_sources)[1]))
-        remaining_candidates = self.__candidates_len - current_line \
+        remaining_candidates = self.__candidates_len - current_index \
             - forward_times
         if next(forward_sources, None) is None:
-            # if the cursor is on the last source
+            # If the cursor is on the last source
             self.__cursor = 0
             self.__win_cursor = 1
         elif self.__candidates_len < self.__winheight:
-            # if there is a space under the candidates
+            # If there is a space under the candidates
             self.__cursor = 0
             self.__win_cursor += forward_times
         elif remaining_candidates < self.__winheight:
@@ -526,8 +526,8 @@ class Default(object):
         if len(self.__context['sources']) == 1:
             return
 
-        current_line = self.__cursor + self.__win_cursor - 1
-        backward_candidates = reversed(self.__candidates[:current_line + 1])
+        current_index = self.__cursor + self.__win_cursor - 1
+        backward_candidates = reversed(self.__candidates[:current_index + 1])
         backward_sources = groupby(
             backward_candidates,
             lambda candidate: candidate['source']
@@ -535,7 +535,7 @@ class Default(object):
         current_source = list(next(backward_sources)[1])
         try:
             prev_source = list(next(backward_sources)[1])
-        except StopIteration:  # if the cursor is on the first source
+        except StopIteration:  # If the cursor is on the first source
             last_source = takewhile(
                 lambda candidate:
                     candidate['source'] == self.__candidates[-1]['source'],
@@ -553,7 +553,7 @@ class Default(object):
                 self.__win_cursor = 1
         else:
             back_times = len(current_source) - 1 + len(prev_source)
-            remaining_candidates = self.__candidates_len - current_line \
+            remaining_candidates = self.__candidates_len - current_index \
                 + back_times
             if self.__candidates_len < self.__winheight:
                 self.__cursor = 0

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -498,13 +498,19 @@ class Default(object):
 
         current_line = self.__cursor + self.__win_cursor - 1
         forward_candidates = self.__candidates[current_line:]
-        forward_sources = groupby(forward_candidates, lambda candidate: candidate['source'])
+        forward_sources = groupby(
+            forward_candidates,
+            lambda candidate: candidate['source']
+        )
         forward_times = len(list(next(forward_sources)[1]))
-        remaining_candidates = self.__candidates_len - current_line - forward_times
-        if next(forward_sources, None) is None:  # if the cursor is on the last source
+        remaining_candidates = self.__candidates_len - current_line \
+            - forward_times
+        if next(forward_sources, None) is None:
+            # if the cursor is on the last source
             self.__cursor = 0
             self.__win_cursor = 1
-        elif self.__candidates_len < self.__winheight:  # if there is a space under the candidates
+        elif self.__candidates_len < self.__winheight:
+            # if there is a space under the candidates
             self.__cursor = 0
             self.__win_cursor += forward_times
         elif remaining_candidates < self.__winheight:
@@ -522,13 +528,17 @@ class Default(object):
 
         current_line = self.__cursor + self.__win_cursor - 1
         backward_candidates = reversed(self.__candidates[:current_line + 1])
-        backward_sources = groupby(backward_candidates, lambda candidate: candidate['source'])
+        backward_sources = groupby(
+            backward_candidates,
+            lambda candidate: candidate['source']
+        )
         current_source = list(next(backward_sources)[1])
         try:
             prev_source = list(next(backward_sources)[1])
         except StopIteration:  # if the cursor is on the first source
             last_source = takewhile(
-                lambda candidate: candidate['source'] == self.__candidates[-1]['source'],
+                lambda candidate:
+                    candidate['source'] == self.__candidates[-1]['source'],
                 reversed(self.__candidates)
             )
             len_last_source = len(list(last_source))
@@ -543,7 +553,8 @@ class Default(object):
                 self.__win_cursor = 1
         else:
             back_times = len(current_source) - 1 + len(prev_source)
-            remaining_candidates = self.__candidates_len - current_line + back_times
+            remaining_candidates = self.__candidates_len - current_line \
+                + back_times
             if self.__candidates_len < self.__winheight:
                 self.__cursor = 0
                 self.__win_cursor -= back_times

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -504,12 +504,15 @@ class Default(object):
         if next(forward_sources, None) is None:  # if the cursor is on the last source
             self.__cursor = 0
             self.__win_cursor = 1
-        elif remaining_candidates >= self.__winheight:
-            self.__cursor += forward_times + self.__win_cursor - 1
-            self.__win_cursor = 1
-        else:
+        elif self.__candidates_len < self.__winheight:  # if there is a space under the candidates
+            self.__cursor = 0
+            self.__win_cursor += forward_times
+        elif remaining_candidates < self.__winheight:
             self.__cursor = self.__candidates_len - self.__winheight + 1
             self.__win_cursor = self.__winheight - remaining_candidates
+        else:
+            self.__cursor += forward_times + self.__win_cursor - 1
+            self.__win_cursor = 1
 
         self.update_buffer()
 
@@ -529,21 +532,27 @@ class Default(object):
                 reversed(self.__candidates)
             )
             len_last_source = len(list(last_source))
-            if len_last_source >= self.__winheight:
-                self.__cursor = self.__candidates_len - len_last_source
-                self.__win_cursor = 1
-            else:
+            if self.__candidates_len < self.__winheight:
+                self.__cursor = 0
+                self.__win_cursor = self.__candidates_len - len_last_source + 1
+            elif len_last_source < self.__winheight:
                 self.__cursor = self.__candidates_len - self.__winheight + 1
                 self.__win_cursor = self.__winheight - len_last_source
+            else:
+                self.__cursor = self.__candidates_len - len_last_source
+                self.__win_cursor = 1
         else:
             back_times = len(current_source) - 1 + len(prev_source)
             remaining_candidates = self.__candidates_len - current_line + back_times
-            if remaining_candidates >= self.__winheight:
-                self.__cursor -= back_times - self.__win_cursor + 1
-                self.__win_cursor = 1
-            else:
+            if self.__candidates_len < self.__winheight:
+                self.__cursor = 0
+                self.__win_cursor -= back_times
+            elif remaining_candidates < self.__winheight:
                 self.__cursor = self.__candidates_len - self.__winheight + 1
                 self.__win_cursor = self.__winheight - remaining_candidates
+            else:
+                self.__cursor -= back_times - self.__win_cursor + 1
+                self.__win_cursor = 1
 
         self.update_buffer()
 

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -493,6 +493,9 @@ class Default(object):
             return
 
     def jump_to_next_source(self):
+        if len(self.__context['sources']) == 1:
+            return
+
         current_line = self.__cursor + self.__win_cursor - 1
         forward_candidates = self.__candidates[current_line:]
         forward_sources = groupby(forward_candidates, lambda candidate: candidate['source'])
@@ -511,6 +514,9 @@ class Default(object):
         self.update_buffer()
 
     def jump_to_prev_source(self):
+        if len(self.__context['sources']) == 1:
+            return
+
         current_line = self.__cursor + self.__win_cursor - 1
         backward_candidates = reversed(self.__candidates[:current_line + 1])
         backward_sources = groupby(backward_candidates, lambda candidate: candidate['source'])

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -12,7 +12,7 @@ from .. import denite
 import re
 import traceback
 import time
-from itertools import filterfalse
+from itertools import filterfalse, groupby
 
 
 class Default(object):
@@ -491,6 +491,23 @@ class Default(object):
             self.__cursor = max(self.__cursor - scroll, 0)
         else:
             return
+
+    def jump_to_next_source(self):
+        current_line = self.__cursor + self.__win_cursor - 1
+        forward_candidates = self.__candidates[current_line:]
+        forward_sources = groupby(forward_candidates, lambda candidate: candidate['source'])
+        forward_times = len(list(next(forward_sources)[1]))
+        remaining_candidates = self.__candidates_len - current_line - forward_times
+        if next(forward_sources, None) is None:  # if the cursor is on the last source
+            self.__cursor = 0
+            self.__win_cursor = 1
+        elif remaining_candidates >= self.__winheight:
+            self.__cursor += forward_times + self.__win_cursor - 1
+            self.__win_cursor = 1
+        else:
+            self.__cursor = self.__candidates_len - self.__winheight + 1
+            self.__win_cursor = self.__winheight - remaining_candidates
+
         self.update_buffer()
 
     def input_command_line(self):


### PR DESCRIPTION
![](http://g.recordit.co/rChkLWM6yE.gif)
I have implemented a feature like [unite_rotate_next_source](https://github.com/Shougo/unite.vim/blob/master/doc/unite.txt#L967)
I'm using it with init.vim like this
```vim
call denite#custom#map('insert', '<LEFT>', 'jump_to_prev_source')
call denite#custom#map('insert', '<RIGHT>', 'jump_to_next_source')
```