### PR TITLE
Add first/last movement feature

### DIFF
--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -85,6 +85,8 @@ function! denite#init#_variables() abort "{{{
         \ "i": 'enter_mode:insert',
         \ "j": 'move_to_next_line',
         \ "k": 'move_to_prev_line',
+        \ "g": 'move_to_first_line',
+        \ "G": 'move_to_last_line',
         \ "<C-d>": 'scroll_window_downwards',
         \ "<C-u>": 'scroll_window_upwards',
         \ "<C-f>": 'scroll_page_forwards',

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -265,6 +265,14 @@ move_to_next_line
 move_to_prev_line
 		Move to previous line.
 
+						*denite-map-move_to_first_line*
+move_to_first_line
+		Move to first line.
+
+						*denite-map-move_to_last_line*
+move_to_last_line
+		Move to last line.
+
 					*denite-map-scroll_window_downwards*
 scroll_window_downwards
 		Scroll the window downwards.
@@ -333,6 +341,8 @@ All mode mappings.
 i		enter_mode:insert
 j		move_to_next_line
 k		move_to_prev_line
+g		move_to_first_line
+G		move_to_last_line
 <C-d>		scroll_window_downwards
 <C-u>		scroll_window_upwards
 <C-f>		scroll_page_forwards

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -460,6 +460,20 @@ class Default(object):
             return
         self.update_buffer()
 
+    def move_to_first_line(self):
+        if self.__win_cursor > 1 or self.__cursor > 0:
+            self.__win_cursor = 1
+            self.__cursor = 0
+            self.update_buffer()
+
+    def move_to_last_line(self):
+        win_max = min(self.__candidates_len, self.__winheight)
+        cur_max = self.__candidates_len - win_max
+        if self.__win_cursor < win_max or self.__cursor < cur_max:
+            self.__win_cursor = win_max
+            self.__cursor = cur_max
+            self.update_buffer()
+
     def scroll_window_upwards(self):
         self.scroll_up(self.__scroll)
 


### PR DESCRIPTION
- `move_to_first_line`: Move to the _first_ line of list.
- `move_to_last_line`: Move to the _last_ line of list.
- New _normal_ key-mappings:
  - `g` for moving to first line
  - `G` for moving to last line