### PR TITLE
Implement sorter_sublime

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -757,6 +757,12 @@ sorter_rank
 		length is shorter, the rank is higher.  This sorter is useful
 		for file candidate source.
 
+
+						*denite-filter-sorter_sublime*
+sorter_sublime
+		Uses the scoring algorithm from this article and its implementation:
+		https://bit.ly/reverse-engineering-sublime-text-s-fuzzy-match
+
 				*denite-filter-converter_relative_word*
 converter_relative_word
 		Convert candidate's word to the relative path.

--- a/rplugin/python3/denite/filter/sorter_sublime.py
+++ b/rplugin/python3/denite/filter/sorter_sublime.py
@@ -1,0 +1,124 @@
+from .base import Base
+
+
+class Filter(Base):
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'sorter_sublime'
+        self.description = 'sorter for fuzzy matching like sublime text based on lib_fts'
+
+    def filter(self, context):
+        if len(context['input']) == 0:
+            return context['candidates']
+
+        for candidate in context['candidates']:
+            candidate['filter__rank'] = get_score(context['input'], candidate['word'])
+
+        return sorted(context['candidates'], key=lambda candidate: -candidate['filter__rank'])
+
+
+# This is porting of https://github.com/forrestthewoods/lib_fts/blob/master/code/fts_fuzzy_match.js
+def get_score(pattern, candidate):
+    # Score consts
+    ADJACENCY_BONUS = 5  # bonus for adjacent matches
+    SEPARATOR_BONUS = 10  # bonus if match occurs after a separato
+    CAMEL_BONUS = 10  # bonus if match is uppercase and prev is lower
+    LEADING_LETTER_PENALTY = -3  # penalty applied for every letter in str before the first match
+    MAX_LEADING_LETTER_PENALTY = -9  # maximum penalty for leading letters
+    UNMATCHED_LETTER_PENALTY = -1  # penalty for every letter that doesn't matter
+
+    # Loop variables
+    score = 0
+    pattern_index = 0
+    pattern_length = len(pattern)
+    candidate_index = 0
+    candidate_length = len(candidate)
+    prev_matched = False
+    prev_lower = False
+    prev_separator = True  # true so if first letter match gets separator bonus
+
+    # Use "best" matched letter if multiple string letters match the pattern
+    best_letter = None
+    best_lower = None
+    best_letter_index = None
+    best_letter_score = 0
+
+    matched_indices = []
+
+    # Loop over strings
+    while candidate_index != candidate_length:
+        pattern_char = pattern[pattern_index] if pattern_index != pattern_length else None
+        candidate_char = candidate[candidate_index]
+
+        pattern_lower = pattern_char.lower() if pattern_char is not None else None
+        candidate_lower = candidate_char.lower()
+        candidate_upper = candidate_char.upper()
+
+        next_match = pattern_char and pattern_lower == candidate_lower
+        rematch = best_letter and best_lower == candidate_lower
+
+        advanced = next_match and best_letter
+        pattern_repeat = best_letter and pattern_char and best_lower == pattern_lower
+        if advanced or pattern_repeat:
+            score += best_letter_score
+            matched_indices.append(best_letter_index)
+            best_letter = None
+            best_lower = None
+            best_letter_index = None
+            best_letter_score = 0
+
+        if next_match or rematch:
+            new_score = 0
+
+            # Apply penalty for each letter before the first pattern match
+            # Note: std::max because penalties are negative values. So max is smallest penalty.
+            if pattern_index == 0:
+                penalty = max(candidate_index * LEADING_LETTER_PENALTY, MAX_LEADING_LETTER_PENALTY)
+                score += penalty
+
+            # Apply bonus for consecutive bonuses
+            if prev_matched:
+                new_score += ADJACENCY_BONUS
+
+            # Apply bonus for matches after a separator
+            if prev_separator:
+                new_score += SEPARATOR_BONUS
+
+            # Apply bonus across camel case boundaries. Includes "clever" isLetter check.
+            if prev_lower and candidate_char == candidate_upper and candidate_lower != candidate_upper:
+                new_score += CAMEL_BONUS
+
+            # Update patter index IFF the next pattern letter was matched
+            if next_match:
+                pattern_index += 1
+
+            # Update best letter in str which may be for a "next" letter or a "rematch"
+            if new_score >= best_letter_score:
+                # Apply penalty for now skipped letter
+                if best_letter is not None:
+                    score += UNMATCHED_LETTER_PENALTY
+
+                best_letter = candidate_char
+                best_lower = best_letter.lower()
+                best_letter_index = candidate_index
+                best_letter_score = new_score
+
+            prev_matched = True
+        else:
+            # Append unmatch characters
+            score += UNMATCHED_LETTER_PENALTY
+            prev_matched = False
+
+        # Includes "clever" isLetter check.
+        prev_lower = candidate_char == candidate_lower and candidate_lower != candidate_upper
+        prev_separator = candidate_char == '_' or candidate_char == ' '
+
+        candidate_index += 1
+
+    # Apply score for last match
+    if best_letter:
+        score += best_letter_score
+        matched_indices.append(best_letter_index)
+
+    return score

--- a/rplugin/python3/denite/filter/sorter_sublime.py
+++ b/rplugin/python3/denite/filter/sorter_sublime.py
@@ -1,3 +1,12 @@
+# ============================================================================
+# FILE: sorter_sublime.py
+# AUTHOR: Tomoki Ohno <wh11e7rue@icloud.com>
+# DESCRIPTION: Base code is from
+# https://github.com/forrestthewoods/lib_fts/blob/master/code/fts_fuzzy_match.js
+#              See explanation in
+#              http://bit.ly/reverse-engineering-sublime-text-s-fuzzy-match
+# License: MIT license
+# ============================================================================
 from .base import Base
 from unicodedata import category
 
@@ -24,8 +33,6 @@ class Filter(Base):
         )
 
 
-# This is porting of
-# https://github.com/forrestthewoods/lib_fts/blob/master/code/fts_fuzzy_match.js
 def get_score(pattern, candidate):
     # Score consts
     # bonus for adjacent matches

--- a/rplugin/python3/denite/filter/sorter_sublime.py
+++ b/rplugin/python3/denite/filter/sorter_sublime.py
@@ -1,4 +1,5 @@
 from .base import Base
+from unicodedata import category
 
 
 class Filter(Base):
@@ -112,7 +113,8 @@ def get_score(pattern, candidate):
 
         # Includes "clever" isLetter check.
         prev_lower = candidate_char == candidate_lower and candidate_lower != candidate_upper
-        prev_separator = candidate_char == '_' or candidate_char == ' '
+        prev_separator = category(candidate_char)[0] != 'L'
+        # Modified from the original. See http://www.fileformat.info/info/unicode/category/index.htm
 
         candidate_index += 1
 


### PR DESCRIPTION
I have implemented a sorter like Sublime Text's fuzzy matching based on [this article](https://blog.forrestthewoods.com/reverse-engineering-sublime-text-s-fuzzy-match-4cffeed33fdb) and [its implementation](https://github.com/forrestthewoods/lib_fts/blob/master/code/fts_fuzzy_match.js#L33).

I'm using it with init.vim like this:
```vim
  call denite#custom#source('buffer,file_rec,file_mru', 'sorters', ['sorter_sublime'])
```

sorter_sublime:
![2016-11-22 1 04 32](https://cloud.githubusercontent.com/assets/12756700/20491038/6ce9efd2-b053-11e6-8dd8-adae64dc0214.png)

sorter_rank:
![2016-11-22 1 02 49](https://cloud.githubusercontent.com/assets/12756700/20491028/645a6bee-b053-11e6-8a0e-178d0d139cf2.png)
