### PR TITLE
Fix yank action register

### DIFF
--- a/rplugin/python3/denite/kind/base.py
+++ b/rplugin/python3/denite/kind/base.py
@@ -21,4 +21,4 @@ class Base(object):
         self.__yank(self.vim, target['word'])
 
     def __yank(self, vim, word):
-        vim.call('setreg', '"', word, 'v')
+        vim.call('setreg', self.vim.eval('v:register'), word, 'v')

--- a/rplugin/python3/denite/kind/base.py
+++ b/rplugin/python3/denite/kind/base.py
@@ -22,5 +22,5 @@ class Base(object):
 
     def __yank(self, vim, word):
         vim.call('setreg', '"', word, 'v')
-        if vim.eval('has("clipboard")') == 1:
+        if vim.call('has', 'clipboard'):
             vim.call('setreg', vim.eval('v:register'), word, 'v')

--- a/rplugin/python3/denite/kind/base.py
+++ b/rplugin/python3/denite/kind/base.py
@@ -21,4 +21,6 @@ class Base(object):
         self.__yank(self.vim, target['word'])
 
     def __yank(self, vim, word):
-        vim.call('setreg', self.vim.eval('v:register'), word, 'v')
+        vim.call('setreg', '"', word, 'v')
+        if vim.eval('has("clipboard")') == 1:
+            vim.call('setreg', vim.eval('v:register'), word, 'v')


### PR DESCRIPTION
In PR #73, I yanked only `"`" register.  I added `v:register` if has('clipboard'), like `Unite`