### PR TITLE
fix '-no-' bool option completion

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -19,7 +19,7 @@ function! denite#helper#complete(arglead, cmdline, cursorpos) abort "{{{
     let _ += map(copy(string_options), "'-' . tr(v:val, '_', '-') . '='")
 
     " Add "-no-" option names completion.
-    let _ += map(copy(bool_options), "'-no-' . v:val")
+    let _ += map(copy(bool_options), "'-no-' . tr(v:val, '_', '-')")
   else
     " Source name completion.
     let _ += map(globpath(&runtimepath,


### PR DESCRIPTION
If option_name included '_', it is replaced '-' in completion, but In completion with '-no-', it is not replaced.
