### PR TITLE
Return 0x03 in Vim 8.0 when user hit <C-c>

### DIFF
--- a/rplugin/python3/denite/prompt/util.py
+++ b/rplugin/python3/denite/prompt/util.py
@@ -120,6 +120,8 @@ def getchar(nvim, *args):
         if isinstance(ret, int):
             return ret
         return ensure_bytes(nvim, ret)
+    except KeyboardInterrupt:
+        return 0x03
     except nvim.error as e:
         # NOTE:
         # Vim returns 0x03 when ^C is pressed but Neovim.


### PR DESCRIPTION
To fix #84