### PR TITLE
fix foward match to exact match in file open action.

### DIFF
--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -20,16 +20,17 @@ class Kind(Base):
     def action_open(self, context):
         target = context['targets'][0]
         path = target['action__path']
+        match_path = '^{0}$'.format(path)
 
         if re.match('^\w+://', path):
             # URI
             self.vim.call('denite#util#open', path)
             return
 
-        if self.vim.call('bufwinnr', path) <= 0:
+        if self.vim.call('bufwinnr', match_path) <= 0:
             self.vim.call(
                 'denite#util#execute_path', 'edit', path)
-        elif self.vim.call('bufwinnr', path) != self.vim.current.buffer:
+        elif self.vim.call('bufwinnr', match_path) != self.vim.current.buffer:
             self.vim.call(
                 'denite#util#execute_path', 'buffer', path)
         self.__jump(context, target)


### PR DESCRIPTION
Candidates of `file_rec` is followin state

```
aaa
aaa.bbb
```
With `aaa.bbb` was already opened, I chose `aaa`. but `aaa` was not opened and buffer contents kept  `aaa.bbb`.

I refered to https://github.com/vim-jp/issues/issues/990#issuecomment-263584439