### PR TITLE
Do not use denite#util#open for URIs supported by Netrw

### DIFF
--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -22,7 +22,7 @@ class Kind(Base):
         path = target['action__path']
         match_path = '^{0}$'.format(path)
 
-        if re.match('^\w+://', path):
+        if re.match('^(?!dav|fetch|ftp|http|rcp|rsync|scp|sftp)\w+://', path):
             # URI
             self.vim.call('denite#util#open', path)
             return

--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -22,7 +22,7 @@ class Kind(Base):
         path = target['action__path']
         match_path = '^{0}$'.format(path)
 
-        if re.match('^(?!dav|fetch|ftp|http|rcp|rsync|scp|sftp)\w+://', path):
+        if re.match('^(?!dav|fetch|ftp|rcp|rsync|scp|sftp)\w+://', path):
             # URI
             self.vim.call('denite#util#open', path)
             return


### PR DESCRIPTION
Netrw is included in all Vim/Neovim versions. Netrw can open various uri schemes (e.g. scp://server/filename). Without this patch, opening such URI schemes (e.g. from a file_mru menu) will open the file with the system's URI handler. With this patch, netrw will take care of opening the file in Vim/Neovim.