### PR TITLE
Display "No Name" when there is empty buffer name

### DIFF
--- a/rplugin/python3/denite/source/buffer.py
+++ b/rplugin/python3/denite/source/buffer.py
@@ -57,7 +57,8 @@ class Source(Base):
                 str(buffer_attr['number']).rjust(
                     len('{}'.format(len(self.vim.buffers))) + 1, ' '),
                 buffer_attr['status'],
-                self.vim.call('fnamemodify', buffer_attr['name'], ':~:.'),
+                self.vim.call('fnamemodify', buffer_attr['name'], ':~:.')
+                if buffer_attr['name'] != '' else 'No Name',
                 ' [{}]'.format(
                     buffer_attr['filetype']
                 ) if buffer_attr['filetype'] != '' else '',


### PR DESCRIPTION
Displaying the empty buffer intention in buffer source displays the current directory.
It is displayed as "No Name" like unite.vim.