### PR TITLE
Except 'base' from source name completion

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -22,9 +22,10 @@ function! denite#helper#complete(arglead, cmdline, cursorpos) abort "{{{
     let _ += map(copy(bool_options), "'-no-' . tr(v:val, '_', '-')")
   else
     " Source name completion.
-    let _ += map(globpath(&runtimepath,
-          \ 'rplugin/python3/denite/source/*.py', 1, 1),
-          \ "fnamemodify(v:val, ':t:r')")
+    let _ += filter(map(globpath(&runtimepath,
+          \             'rplugin/python3/denite/source/*.py', 1, 1),
+          \             "fnamemodify(v:val, ':t:r')"),
+          \         "v:val != 'base'")
   endif
 
   return uniq(sort(filter(_, 'stridx(v:val, a:arglead) == 0')))


### PR DESCRIPTION
I think that it is better to exclude "base" from source name completion.