### PR TITLE
Fix async updating issue.

### DIFF
--- a/rplugin/python3/denite/ui/prompt.py
+++ b/rplugin/python3/denite/ui/prompt.py
@@ -57,6 +57,11 @@ class DenitePrompt(Prompt):
         if self.denite.is_async:
             self.denite.update_candidates()
             self.denite.update_buffer()
+            # NOTE
+            # Redraw prompt to update the buffer.
+            # Without 'redraw_prompt', the buffer is not updated often enough
+            # for 'async' source.
+            self.redraw_prompt()
 
     def on_keypress(self, keystroke):
         m = ACTION_KEYSTROKE_PATTERN.match(str(keystroke))


### PR DESCRIPTION
The candidates on the buffer was not updated often enough compared to the previous denite.nvim
Fix that issue by calling 'redraw' internally when 'async' is enabled.