### PR TITLE
Fix neovim-prompt builtin mapping actions

### DIFF
--- a/rplugin/python3/denite/prompt/.travis.yml
+++ b/rplugin/python3/denite/prompt/.travis.yml
@@ -4,12 +4,31 @@ python:
   - 3.3
   - 3.4
   - 3.5
+os:
+  - linux
+  - osx
+osx_image: xcode8
+
+addons:
+  apt:
+    packages:
+      - libtool
+      # - libtool-bin # is only required for Ubuntu 16.04/Debian Jessie and newer.
+      - autoconf
+      - automake
+      - cmake
+      - g++
+      - pkg-config
+      - unzip
 
 install:
+  - curl -sL git.io/v18DU | bash
+  - pip install neovim
   - pip install coveralls
   - git clone --depth 1 --single-branch -b ci-test https://github.com/lambdalisue/neovim-prompt ci-test
 
 script:
+  - export PATH="$HOME/neovim/bin:$PATH"
   - cd ci-test
   - sh ./scripts/test.sh
 

--- a/rplugin/python3/denite/prompt/util.pyi
+++ b/rplugin/python3/denite/prompt/util.pyi
@@ -1,5 +1,12 @@
-from typing import Any, AnyStr, Union
+from typing import Any, AnyStr, Union, NamedTuple
+
 from neovim import Nvim
+
+
+PatternSet = NamedTuple('PatternSet', [
+    ('pattern', str),
+    ('inverse', str),
+])
 
 
 def get_encoding(nvim: Nvim) -> str: ...
@@ -21,6 +28,9 @@ def getchar(nvim: Nvim, *args) -> Union[int, bytes]: ...
 
 
 def build_echon_expr(text: str, hl: str) -> str: ...
+
+
+def build_keyword_pattern_set(nvim: Nvim) -> PatternSet: ...
 
 
 class Singleton(type):


### PR DESCRIPTION
Followed the latest neovim-prompt which fixed the followings

- `<prompt:move_caret_to_one_word_left>` and `<prompt:move_caret_to_one_word_right>`

  It seems the native Vim does not respect `iskeyword` for moving caret by `<S-Left>` or `<S-Right>` so the changes followed the Vim's flavor.
  - [Spec1](https://github.com/lambdalisue/neovim-prompt/blob/0b0d010d558b77b70870d9c924c7834500b16b27/test/test_action.py#L434-L472)
  - [Spec2](https://github.com/lambdalisue/neovim-prompt/blob/0b0d010d558b77b70870d9c924c7834500b16b27/test/test_action.py#L511-L549)

- `<prompt:delete_word_before_caret>`

  Previously the mapping action cannot remove characters which is not listed in `iskeyword`.
  The changes fixed that issue and close the behavior to the one of the native Vim.
  - [Spec](https://github.com/lambdalisue/neovim-prompt/blob/0b0d010d558b77b70870d9c924c7834500b16b27/test/test_action.py#L125-L189)

- `<prompt:delete_word_after_caret>`

  Previously the mapping action cannot remove characters which is not listed in `iskeyword`.
  The changes fixed that issue and close the behavior to the `w` in Normal mode of the native Vim.
  - [Spec](https://github.com/lambdalisue/neovim-prompt/blob/0b0d010d558b77b70870d9c924c7834500b16b27/test/test_action.py#L214-L297)

- `<prompt:delete_word_under_caret>`

  Previously the mapping action cannot remove characters which is not listed in `iskeyword`.
  The changes fixed that issue and close the behavior to the `diw` in Normal mode of the native Vim.
  - [Spec](https://github.com/lambdalisue/neovim-prompt/blob/0b0d010d558b77b70870d9c924c7834500b16b27/test/test_action.py#L308-L391)