### PR TITLE
Fix test for existence of keyword argument in `parse_command`

### DIFF
--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -132,8 +132,9 @@ def convert2regex_pattern(input):
 
 def parse_command(array, **kwargs):
     def parse_arg(arg):
-        if (arg.startswith(":") and kwargs[arg[1:]]):
-            return kwargs[arg[1:]]
+        arg = arg[1:]
+        if arg.startswith(":") and arg in kwargs:
+            return kwargs[arg]
         return arg
 
-    return map(parse_arg, array)
+    return [parse_arg(i) for i in array]


### PR DESCRIPTION
The test was like `kwargs[arg]` which throws an exception if there is no
keyword argument named `arg` instead of returning false. `arg in kwargs`
will return false and thus work in an if-clause.

This commit also uses a more idiomatic approach on returning the parsed
command in the end.

I noticed that after the other PR was merged, so I needed to create a
new one.