### PR TITLE
Add '-use-default-mappings' option to allow disabling default mapping

### DIFF
--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -92,7 +92,7 @@ function! denite#init#_user_options() abort
         \ 'scroll': 0,
         \ 'short_source_names': v:false,
         \ 'statusline': v:true,
-        \ 'use_default_mapping': v:true,
+        \ 'use_default_mappings': v:true,
         \ 'vertical_preview': v:false,
         \ 'winheight': 20,
         \}

--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -92,6 +92,7 @@ function! denite#init#_user_options() abort
         \ 'scroll': 0,
         \ 'short_source_names': v:false,
         \ 'statusline': v:true,
+        \ 'use_default_mapping': v:true,
         \ 'vertical_preview': v:false,
         \ 'winheight': 20,
         \}

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -855,9 +855,9 @@ OPTIONS							*denite-options*
 		Enable statusline.
 		Default: true
 
-					*denite-options-use-default-mapping*
--use-default-mapping
-		Enable default key mapping.
+					*denite-options-use-default-mappings*
+-use-default-mappings
+		Enable default key mappings.
 
 		Note that fundemental mappings including <Esc> or <Enter> are
 		also provided by the default key mappings. So disabling this

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -855,6 +855,18 @@ OPTIONS							*denite-options*
 		Enable statusline.
 		Default: true
 
+					*denite-options-use-default-mapping*
+-use-default-mapping
+		Enable default key mapping.
+
+		Note that fundemental mappings including <Esc> or <Enter> are
+		also provided by the default key mappings. So disabling this
+		option without proper custom mappings would make denite
+		useless. Use <C-c> to quit the denite if you accidentally
+		disable this option.
+
+		Default: true
+
 					*denite-options-vertical-preview*
 -vertical-preview
 		Open the preview window vertically.

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -333,13 +333,13 @@ class Default(object):
     def change_mode(self, mode):
         self.__current_mode = mode
         custom = self.__context['custom']['map']
-        use_default_mapping = self.__context['use_default_mapping']
+        use_default_mappings = self.__context['use_default_mappings']
 
         # Clear current keymap
         self.__prompt.keymap.registry.clear()
 
         # Apply mode independent mappings
-        if use_default_mapping:
+        if use_default_mappings:
             self.__prompt.keymap.register_from_rules(
                 self.__vim,
                 DEFAULT_ACTION_KEYMAP.get('_', [])
@@ -351,7 +351,7 @@ class Default(object):
 
         # Apply mode depend mappings
         mode = self.__current_mode
-        if use_default_mapping:
+        if use_default_mappings:
             self.__prompt.keymap.register_from_rules(
                 self.__vim,
                 DEFAULT_ACTION_KEYMAP.get(mode, [])

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -333,15 +333,17 @@ class Default(object):
     def change_mode(self, mode):
         self.__current_mode = mode
         custom = self.__context['custom']['map']
+        use_default_mapping = self.__context['use_default_mapping']
 
         # Clear current keymap
         self.__prompt.keymap.registry.clear()
 
         # Apply mode independent mappings
-        self.__prompt.keymap.register_from_rules(
-            self.__vim,
-            DEFAULT_ACTION_KEYMAP.get('_', [])
-        )
+        if use_default_mapping:
+            self.__prompt.keymap.register_from_rules(
+                self.__vim,
+                DEFAULT_ACTION_KEYMAP.get('_', [])
+            )
         self.__prompt.keymap.register_from_rules(
             self.__vim,
             custom.get('_', [])
@@ -349,10 +351,11 @@ class Default(object):
 
         # Apply mode depend mappings
         mode = self.__current_mode
-        self.__prompt.keymap.register_from_rules(
-            self.__vim,
-            DEFAULT_ACTION_KEYMAP.get(mode, [])
-        )
+        if use_default_mapping:
+            self.__prompt.keymap.register_from_rules(
+                self.__vim,
+                DEFAULT_ACTION_KEYMAP.get(mode, [])
+            )
         self.__prompt.keymap.register_from_rules(
             self.__vim,
             custom.get(mode, [])


### PR DESCRIPTION
This commit close #112

Users can disable **all** default mappings by

```
:Denite -no-use-default-mappings
```

Note that without proper custom mappings, the command above make the denite useless. Use `<C-c>` to quit if you accidentally disable the option.