### PR TITLE
Fix not recognizing different options

### DIFF
--- a/rplugin/python3/denite/denite.py
+++ b/rplugin/python3/denite/denite.py
@@ -226,7 +226,7 @@ class Denite(object):
 
         kinds = set()
         for target in targets:
-            if 'kind' in targets:
+            if 'kind' in target:
                 kind_name = target['kind']
             else:
                 kind_name = self.__sources[target['source']].kind


### PR DESCRIPTION
When I had, for example, a menu, where some menus were commands and some menus were files, it did not work.

The problem was that the iteration was not actually selecting the right items. I fixed the typo.