### PR TITLE
fix alias syntax_name

### DIFF
--- a/rplugin/python3/denite/denite.py
+++ b/rplugin/python3/denite/denite.py
@@ -169,6 +169,7 @@ class Denite(object):
                     self.__sources[alias] = module.Source(self.__vim)
                     self.__sources[alias].name = alias
                     self.__sources[alias].path = path
+                    self.__sources[alias].syntax_name = source.syntax_name
 
     def get_filter(self, filter_name):
         return self.__filters.get(filter_name, None)


### PR DESCRIPTION
If alias is defined from source that have no syntax name, Denite  crashed using it.

```
Error detected while processing function dein#autoload#_on_cmd[13]..denite#helper#call_denite[14]..denite#start[23].._denite_start:
line    1:
[denite] Traceback (most recent call last):
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/__init__.py", line 33, in start
[denite]     return self.__uis[buffer_name].start(args[0], args[1])
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 92, in start
[denite]     self.init_buffer()
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 162, in init_buffer
[denite]     self.__init_syntax()
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 211, in __init_syntax
[denite]     source.define_syntax()
[denite]   File "/Users/pocari/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/source/base.py", line 29, in define_syntax
[denite]     'syntax region ' + self.syntax_name + ' start=// end=/$/ '
[denite]   File "/usr/local/lib/python3.5/site-packages/neovim/api/nvim.py", line 216, in command
[denite]     return self.request('vim_command', string, **kwargs)
[denite]   File "/usr/local/lib/python3.5/site-packages/neovim/api/nvim.py", line 129, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/usr/local/lib/python3.5/site-packages/neovim/msgpack_rpc/session.py", line 98, in request
[denite]     raise self.error_wrapper(err)
[denite] neovim.api.nvim.NvimError: b'Vim(syntax):E399: Not enough arguments: syntax region start=// end=/$/ contains=deniteMatched contained'
[denite] Please execute :messages command.
```

I fixed it.
