### PR TITLE
source: Fix and document unintuitive behavior, Fixes #113

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -142,19 +142,21 @@ EXAMPLES						*denite-examples*
 
 	" Ack command on grep source
 	call denite#custom#var('grep', 'command', ['ack'])
-	call denite#custom#var('grep', 'recursive_opts', [])
-	call denite#custom#var('grep', 'final_opts', [])
-	call denite#custom#var('grep', 'separator', [])
 	call denite#custom#var('grep', 'default_opts',
 			\ ['--ackrc', $HOME.'/.ackrc', '-H',
 			\ '--nopager', '--nocolor', '--nogroup', '--column'])
+	call denite#custom#var('grep', 'recursive_opts', [])
+	call denite#custom#var('grep', 'pattern_opt', ['--match'])
+	call denite#custom#var('grep', 'separator', ['--'])
+	call denite#custom#var('grep', 'final_opts', [])
 	" Ripgrep command on grep source
 	call denite#custom#var('grep', 'command', ['rg'])
-	call denite#custom#var('grep', 'recursive_opts', [])
-	call denite#custom#var('grep', 'final_opts', [])
-	call denite#custom#var('grep', 'separator', ['--'])
 	call denite#custom#var('grep', 'default_opts',
 			\ ['--vimgrep', '--no-heading'])
+	call denite#custom#var('grep', 'recursive_opts', [])
+	call denite#custom#var('grep', 'pattern_opt', ['--regexp'])
+	call denite#custom#var('grep', 'separator', ['--'])
+	call denite#custom#var('grep', 'final_opts', [])
 
 	call denite#custom#source('file_mru', 'converters',
 	      \ ['converter_relative_word'])
@@ -884,8 +886,8 @@ SOURCES							*denite-sources*
 						*denite-source-buffer*
 buffer		Gather buffers and jump to the buffer.
 
-		Source arguments:
-		1. '!' : a flag to show unlisted buffers
+		Source args:
+			0. '!' : a flag to show unlisted buffers
 
 		Source custom variables:
 		date_format	  the format string to show date
@@ -904,8 +906,8 @@ directory_rec	Gather directories recursive and nominates all directory names
 		under the search directory (argument 1) or the current directory
 		(if argument is omitted) as candidates.
 
-		Source arguments:
-		1. the search directory.
+		Source args:
+			0. the search directory
 
 		Source custom variables:
 		command		 the default get directories command
@@ -925,8 +927,8 @@ file_rec	Gather files recursive and nominates all file names under the
 		search directory (argument 1) or the current directory (if
 		argument is omitted) as candidates.
 
-		Source arguments:
-		1. the search directory.
+		Source args:
+			0. the search directory
 
 		Source custom variables:
 		command		the default get files command.
@@ -961,15 +963,15 @@ command		Gather commands and put on ex-mode.
 
 						*denite-source-grep*
 grep		Gather grep results and nominates them.
-		The source executes ["command", "default_opts",
-		"recursive_opts", {arguments}, "separator", "final_opts"]
+		The source executes [command, default_opts, recursive_opts, args[1]...,
+		`pattern_opt, args[2]`..., separator, args[0]... or final_opts]
 		command line.
 		Note: The command result must be "path:linenr:text" pattern.
-		Note: If the input contains the spaces, you must quote it.
 
-		Source arguments:
-		1. the search directory.
-		2. the additional arguments.
+		Source args:
+			0. path string or list of paths
+			1. string or list of arguments
+			2. pattern string or list of patterns
 
 		Source custom variables:
 		command		the default grep command
@@ -978,6 +980,8 @@ grep		Gather grep results and nominates them.
 				(default: ["-inH"])
 		recursive_opts	the recursive search arguments
 				(default: ["-r"])
+		pattern_opt	the pattern option
+				(default: ["-e"]
 		separator	the argument separator
 				(default: ["--"])
 		final_opts	the final arguments
@@ -994,8 +998,8 @@ line
 						*denite-source-menu*
 menu		Gather custom menus.
 
-		Source arguments:
-		1. The desired menu
+		Source args:
+			0. The desired menu
 
 		Source custom variables:
 		menus		dictionary containing menus in key value

--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -54,7 +54,7 @@ def escape(expr):
 
 
 def escape_syntax(expr):
-    return re.sub(r'([/~])', r'\\\1', expr)
+    return re.sub(r'([\^$.*\/~\[\]])', r'\\\1', expr)
 
 
 def escape_fuzzy(string, camelcase):
@@ -97,7 +97,7 @@ def path2project(vim, path):
     return vim.call('denite#util#path2project_directory', path)
 
 
-def parse_jump_line(cwd, line):
+def parse_jump_line(path_head, line):
     m = re.search(r'^(.*):(\d+)(?::(\d+))?:(.*)$', line)
     if not m or not m.group(1) or not m.group(4):
         return []
@@ -113,7 +113,7 @@ def parse_jump_line(cwd, line):
     if not col:
         col = '0'
     if not os.path.isabs(path):
-        path = cwd + '/' + path
+        path = os.path.join(path_head, path)
 
     return [path, linenr, col, text]
 


### PR DESCRIPTION
Fix and document unintuitive behavior for `args` and `path`.

`grep` pattern applies without inserting narrowing text. Pattern always interpreted literally; fixes problems parsing `-`.

Fixes #113