### PR TITLE
Fix buffer syntax highlight

### DIFF
--- a/rplugin/python3/denite/source/buffer.py
+++ b/rplugin/python3/denite/source/buffer.py
@@ -15,7 +15,7 @@ BUFFER_HIGHLIGHT_SYNTAX = [
     {'name': 'Info',     'link': 'PreProc',   're': '\[.\{-}\] '},
     {'name': 'Modified', 'link': 'Statement', 're': '\[.\{-}+\]'},
     {'name': 'NoFile',   'link': 'Function',  're': '\[nofile\]'},
-    {'name': 'Time',     'link': 'Statement', 're': '(.\{-}) '},
+    {'name': 'Time',     'link': 'Statement', 're': '(.\{-})$'},
 ]
 
 


### PR DESCRIPTION
Fix to enable highlight of deniteSource_buffer_Time.

before
![before](https://cloud.githubusercontent.com/assets/33104/21303942/4ea27ce8-c605-11e6-84e7-cddf2abb004a.png)

after
![after](https://cloud.githubusercontent.com/assets/33104/21303945/50b22cae-c605-11e6-9744-0f4ed16d47f7.png)
