### PR TITLE
Fixed an error in file_rec when there is no directory

### DIFF
--- a/rplugin/python3/denite/source/file_rec.py
+++ b/rplugin/python3/denite/source/file_rec.py
@@ -6,7 +6,7 @@
 
 from .base import Base
 from denite.process import Process
-from os.path import relpath, isabs
+from os.path import relpath, isabs, isdir
 from copy import copy
 from denite.util import parse_command
 
@@ -43,6 +43,8 @@ class Source(Base):
             self.__cache = {}
 
         directory = context['__directory']
+        if not isdir(directory):
+            return []
 
         if directory in self.__cache:
             return self.__cache[directory]


### PR DESCRIPTION
The error does not occur even if you specify a directory that does not exist in file_rec source.

```
:Denite file_rec:hoge
[denite] Traceback (most recent call last):
[denite]   File "<string>", line 14, in _temporary_scope
[denite]   File "/home/ubuntu/.ghq/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 87, in start
[denite]     self.__denite.gather_candidates(self.__context)
[denite]   File "/home/ubuntu/.ghq/github.com/Shougo/denite.nvim/rplugin/python3/denite/denite.py", line 50, in gather_candidates
[denite]     candidates = source.gather_candidates(source.context)
[denite]   File "/home/ubuntu/.ghq/github.com/Shougo/denite.nvim/rplugin/python3/denite/source/file_rec.py", line 64, in gather_candidates
[denite]     self.__proc = Process(command, context, directory)
[denite]   File "/home/ubuntu/.ghq/github.com/Shougo/denite.nvim/rplugin/python3/denite/process.py", line 25, in __init__
[denite]     cwd=cwd)
[denite]   File "/usr/lib/python3.5/subprocess.py", line 947, in __init__
[denite]     restore_signals, start_new_session)
[denite]   File "/usr/lib/python3.5/subprocess.py", line 1551, in _execute_child
[denite]     raise child_exception_type(errno_num, err_msg)
[denite] FileNotFoundError: [Errno 2] No such file or directory: 'hoge'
[denite] Please execute :messages command.
```