### PR TITLE
Fix error when nesting Denite command

### DIFF
--- a/autoload/denite/vim.vim
+++ b/autoload/denite/vim.vim
@@ -49,7 +49,8 @@ def _temporary_scope():
             error(nvim, line)
         error(nvim, 'Please execute :messages command.')
 _temporary_scope()
-del _temporary_scope
+if _temporary_scope in dir():
+    del _temporary_scope
 EOF
   return []
 endfunction


### PR DESCRIPTION
Fix a problem that nested Denite command caused the following error.
It occurred in vim8 only.

It occurs when you input ``:Denite menu<CR><CR><ESC>``
```
Error detected while processing function denite#helper#call_denite[14]..denite#start[23]..denite#vim#_start:
line   23:
Traceback (most recent call last):
  File "<string>", line 21, in <module>
NameError: name '_temporary_scope' is not defined
```