### PR TITLE
Add 'ex' action to execute a 'word' as a command

### DIFF
--- a/rplugin/python3/denite/kind/base.py
+++ b/rplugin/python3/denite/kind/base.py
@@ -35,6 +35,9 @@ def _yank(vim, word):
 
 
 def _ex(vim, word):
-    expr = vim.call('input', ':', word, 'command')
+    # NOTE:
+    # <C-b> (\x02) in a command-line move the caret to the beginning.
+    # Somehow the key above works in 'input()' function as well.
+    expr = vim.call('input', ':', ' %s\x02' % word, 'command')
     if expr:
         vim.command(expr)

--- a/rplugin/python3/denite/kind/base.py
+++ b/rplugin/python3/denite/kind/base.py
@@ -18,10 +18,23 @@ class Base(object):
         denite.util.debug(self.vim, expr)
 
     def action_yank(self, context):
-        self.__yank(self.vim, "\n".join(
-            [x['word'] for x in context['targets']]))
+        _yank(self.vim, "\n".join([
+            x['word'] for x in context['targets']
+        ]))
 
-    def __yank(self, vim, word):
-        vim.call('setreg', '"', word, 'v')
-        if vim.call('has', 'clipboard'):
-            vim.call('setreg', vim.eval('v:register'), word, 'v')
+    def action_ex(self, context):
+        _ex(self.vim, "\n".join([
+            x['word'] for x in context['targets']
+        ]))
+
+
+def _yank(vim, word):
+    vim.call('setreg', '"', word, 'v')
+    if vim.call('has', 'clipboard'):
+        vim.call('setreg', vim.eval('v:register'), word, 'v')
+
+
+def _ex(vim, word):
+    expr = vim.call('input', ':', word, 'command')
+    if expr:
+        vim.command(expr)


### PR DESCRIPTION
This PR implement an 'ex' action which was in unite.vim.
Personally, I have not used 'ex' action so the behavior may be not correct. In that case, let me know where I should fix.

@momo-lab Could you try and give me a feedback?