### PR TITLE
Update `context['mode']` on change

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -360,6 +360,9 @@ class Default(object):
             custom.get(mode, [])
         )
 
+        # Update mode in context
+        self.__context['mode'] = mode
+
         # Update mode indicator
         self.update_buffer()
 


### PR DESCRIPTION
I wish `context['mode']` had current mode, but currently it has initial mode.

So update it on change_mode ( at denite.ui.Default ).

I would be pleased if you could merge.