### PR TITLE
[Feature Request][WIP] Add `jump` action to jump opened buffer window

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1106,6 +1106,22 @@ openable	An interface to open the object.
 			vsplit
 				open the object with 'vsplit'.
 
+			switch
+				Switch to the window that is opening the
+				object.
+
+			tabswitch
+				Switch to the window that is opening the
+				object. If it isn't opened, fallback tabopen.
+
+			splitswitch
+				Switch to the window that is opening the
+				object. If it isn't opened, fallback split.
+
+			vsplitswitch
+				Switch to the window that is opening the
+				object. If it isn't opened, fallback vsplit.
+
 						*denite-kind-word*
 word		An interface to paste the text.
 

--- a/rplugin/python3/denite/kind/buffer.py
+++ b/rplugin/python3/denite/kind/buffer.py
@@ -19,10 +19,6 @@ class Kind(Openable):
         for target in context['targets']:
             self.vim.command('buffer {0}'.format(target['action__bufnr']))
 
-    def action_jump(self, context):
-        for target in context['targets']:
-            winids = self.vim.call('win_findbuf', target['action__bufnr'])
-            if len(winids) == 0:
-                self.action_tabopen(context)
-            else:
-                self.vim.call('win_gotoid', winids[0])
+    def __winid(self, target):
+        winids = self.vim.call('win_findbuf', target['action__bufnr'])
+        return None if len(winids) == 0 else winids[0]

--- a/rplugin/python3/denite/kind/buffer.py
+++ b/rplugin/python3/denite/kind/buffer.py
@@ -18,3 +18,11 @@ class Kind(Openable):
     def action_open(self, context):
         for target in context['targets']:
             self.vim.command('buffer {0}'.format(target['action__bufnr']))
+
+    def action_jump(self, context):
+        for target in context['targets']:
+            winids = self.vim.call('win_findbuf', target['action__bufnr'])
+            if len(winids) == 0:
+                self.action_tabopen(context)
+            else:
+                self.vim.call('win_gotoid', winids[0])

--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -89,3 +89,11 @@ class Kind(Openable):
 
         # Open folds
         self.vim.command('normal! zv')
+
+    def __winid(self, target):
+        path = target['action__path']
+        bufnr = self.vim.call('bufnr', path)
+        if bufnr == -1:
+            return None
+        winids = self.vim.call('win_findbuf', bufnr)
+        return None if len(winids) == 0 else winids[0]

--- a/rplugin/python3/denite/kind/openable.py
+++ b/rplugin/python3/denite/kind/openable.py
@@ -50,3 +50,23 @@ class Kind(Base):
                 self.action_open(new_context)
         finally:
             self.vim.options['hidden'] = hidden
+
+    def action_switch(self, context):
+        self.__action_switch(context, self.action_open)
+
+    def action_tabswitch(self, context):
+        self.__action_switch(context, self.action_tabopen)
+
+    def action_splitswitch(self, context):
+        self.__action_switch(context, self.action_split)
+
+    def action_vsplitswitch(self, context):
+        self.__action_switch(context, self.action_vsplit)
+
+    def __action_switch(self, context, fallback):
+        for target in context['targets']:
+            winid = self.__winid(target)
+            if winid:
+                self.vim.call('win_gotoid', winid)
+            else:
+                fallback(context)


### PR DESCRIPTION
Hi

I need a new action for jumping to opened window for buffer source.

Action behavior
------

1. select a buffer by buffer source
1. get window number by `win_findbuf()` function.
    - If window exists, jump to the window by `win_gotoid()`
    - If window doesn't exist, fallback other action (Note: I've implement fallback to tabopen action, but I think the action should be selectable by user. But I don't know how to implement it.)

![dac](https://cloud.githubusercontent.com/assets/4361134/21350261/c0aa0b4a-c6f9-11e6-8e2e-2a93829720af.gif)


Why work in progress
------

As mentioned above, user can't select the fallback action in this implementation. 
Could you tell me how to implement it? 