### PR TITLE
denite#custom#var command fix w/ ':directory' use

### DIFF
--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -132,9 +132,8 @@ def convert2regex_pattern(input):
 
 def parse_command(array, **kwargs):
     def parse_arg(arg):
-        arg = arg[1:]
-        if arg.startswith(":") and arg in kwargs:
-            return kwargs[arg]
+        if arg.startswith(':') and arg[1:] in kwargs:
+            return kwargs[arg[1:]]
         return arg
 
     return [parse_arg(i) for i in array]


### PR DESCRIPTION
The current behaviour when using denite#custom#var('file_rec','command',... will strip off the first character from each arg if ':directory' is used. 

Example .vimrc to observe the broken behaviour:
```
        call denite#custom#var('file_rec', 'command',
            \['find', '-L', ':directory',
            \              "-path", "*.svn", "-prune", "-o",
            \              "-path", "*.git", "-prune", "-o",
            \              "-path", "*obj", "-prune", "-o",
            \              "-path", "*release", "-prune", "-o",
            \              "-name", "*.tags", "-o",
            \              "-name", "*.pyc", "-o",
            \              "-name", "*.so", "-o",
            \              "-name", "*.bin", "-o",
            \              "-name", "*.exe", "-o",
            \              '-type', 'l', '-print', '-o',
            \              '-type', 'f', '-print'])
```

This can be fixed by not stomping over each arg, but instead only return with the lookup in kwargs if needed, else just return the unmodified arg.

