### PR TITLE
preserve exit mode for resume

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -55,7 +55,6 @@ class Default(object):
     def start(self, sources, context):
         if self.__initialized and context['resume']:
             # Skip the initialization
-            self.__current_mode = context['mode']
             self.__context['immediately'] = context['immediately']
             self.__context['cursor_wrap'] = context['cursor_wrap']
 


### PR DESCRIPTION
When `:Denite -resume` is used the mode would always change to `insert`,  I think it's better to preserve the mode.