### PR TITLE
Add winminheight for auto-resize windows

### DIFF
--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -98,7 +98,7 @@ function! denite#init#_user_options() abort
         \ 'use_default_mappings': v:true,
         \ 'vertical_preview': v:false,
         \ 'winheight': 20,
-		\ 'minwinheight': -1,
+		\ 'winminheight': -1,
         \}
 endfunction
 function! denite#init#_deprecated_options() abort

--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -98,6 +98,7 @@ function! denite#init#_user_options() abort
         \ 'use_default_mappings': v:true,
         \ 'vertical_preview': v:false,
         \ 'winheight': 20,
+		\ 'minwinheight': -1,
         \}
 endfunction
 function! denite#init#_deprecated_options() abort

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -892,6 +892,21 @@ OPTIONS							*denite-options*
 		Open the preview window vertically.
 		Default: false
 
+						*denite-options-winheight*
+-winheight={window-height}
+		Set the height of the Denite window. If auto-resize is set,
+		|denite-options-winheight| is the maximum size of the window.
+
+		Default: 20
+
+						*denite-options-winminheight*
+-winminheight={window-height}
+		Set the minimum height of an auto-resize window.
+		Note: a value of -1 for |denite-options-winminheight| leaves
+		the minimum height unset.
+		
+		Default: -1
+
 ==============================================================================
 SOURCES							*denite-sources*
 

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -293,8 +293,8 @@ class Default(object):
                     self.__candidates_len <
                     int(self.__context['winminheight'])):
                 winheight = self.__context['winminheight']
-            elif (self.__candidate_len < self.__winheight):
-                winheight = self.__candidate_len
+            elif (self.__candidates_len < self.__winheight):
+                winheight = self.__candidates_len
 
         self.__vim.command('resize ' + str(winheight))
 

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -43,6 +43,7 @@ class Default(object):
         self.__winsaveview = {}
         self.__initialized = False
         self.__winheight = 0
+        self.__winminheight = -1
         self.__scroll = 0
         self.__is_multi = False
         self.__matched_pattern = ''
@@ -286,9 +287,15 @@ class Default(object):
 
     def resize_buffer(self):
         winheight = self.__winheight
-        if (self.__context['auto_resize'] and
-                self.__candidates_len < self.__winheight):
-            winheight = self.__candidates_len
+
+        if self.__context['auto_resize']:
+            if (self.__context['winminheight'] is not -1 and
+                    self.__candidates_len <
+                    int(self.__context['winminheight'])):
+                winheight = self.__context['winminheight']
+            elif (self.__candidate_len < self.__winheight):
+                winheight = self.__candidate_len
+
         self.__vim.command('resize ' + str(winheight))
 
     def check_empty(self):


### PR DESCRIPTION
Small patch to add minimum height for autoresizing windows. This stops the window from having to redraw its size beyond a certain height when the candidate list is shrinking as I personally find this somewhat distracting.

The naming is the same as the vim/neovim's minimum window height for consistency.

> The 'winheight' option can be set to a minimal desired height of a window and
> 'winminheight' to a hard minimum height.
>    Likewise, there is 'winwidth' for the minimal desired width and
> 'winminwidth' for the hard minimum width.
>    The 'equalalways' option, when set, makes Vim equalize the windows sizes
> when a window is closed or opened.