### PR TITLE
Stop escaping colon in s:eval_cmdline

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -128,7 +128,7 @@ function! s:eval_cmdline(cmdline) abort
     endif
     let prev_match = matchend(a:cmdline,
           \ '\\\@<!`.\{-}\\\@<!`', match)
-    let cmdline .= escape(eval(a:cmdline[match+1 : prev_match - 2]), '\: ')
+    let cmdline .= escape(eval(a:cmdline[match+1 : prev_match - 2]), '\ ')
 
     let match = match(a:cmdline, '\\\@<!`.\{-}\\\@<!`', prev_match)
   endwhile


### PR DESCRIPTION
s:eval_cmdlin escapes colon after adapting eval() to context.
But this might be leaded into error.

Test Case:
   context  Denite `has('nvim') ? file_rec:. : file_rec`