### PR TITLE
Fix code mark

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1246,7 +1246,7 @@ matcher_cpsm
 		https://github.com/nixprime/cpsm
 		Note: You must use Python3 support enabled cpsm. >
 			$ PY3=ON ./install.sh
-
+<
 						*denite-filter-matcher_fuzzy*
 matcher_fuzzy
 		A matcher which filters the candidates with user given fuzzy


### PR DESCRIPTION
It seems to have been judged as a code until "*denite-filter-matcher_fuzzy*".