### PR TITLE
Update neovim prompt

### DIFF
--- a/rplugin/python3/denite/prompt/prompt.py
+++ b/rplugin/python3/denite/prompt/prompt.py
@@ -182,7 +182,6 @@ class Prompt:
                 raise e
         except KeyboardInterrupt:
             status = STATUS_INTERRUPT
-        self.nvim.command('redraw!')
         if self.text:
             self.nvim.call('histadd', 'input', self.text)
         return self.on_term(status)

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -117,6 +117,8 @@ class Default(object):
         # Make sure that the caret position is ok
         self._prompt.caret.locus = self._prompt.caret.tail
         status = self._prompt.start()
+        # Redraw to clear prompt
+        self._vim.command('redraw!')
         if status == STATUS_INTERRUPT:
             # STATUS_INTERRUPT is returned when user hit <C-c> and the loop has
             # interrupted.


### PR DESCRIPTION
This PR does

- Update neovim-prompt
  - neovim-prompt no longer execute `redraw!` automatically
- For instance, denite.nvim execute `redraw!` just after `prompt.start()`

You can move `redraw!` after this PR wherever you want @Shougo 