### PR TITLE
Bind scroll_page to previewwindow when possible

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -568,11 +568,34 @@ class Default(object):
     def scroll_window_downwards(self):
         self.scroll_down(self._scroll)
 
+    def __get_preview_window(self):
+        return next(filterfalse(lambda x:
+                                not x.options['previewwindow'],
+                                self._vim.windows), None)
+
     def scroll_page_backwards(self):
-        self.scroll_up(self._winheight - 1)
+        previewwindow = self.__get_preview_window()
+        if previewwindow:
+            prev_id = self._vim.call('win_getid')
+            wnr = previewwindow.number
+            wid = self._vim.call('win_getid', wnr)
+            self._vim.call('win_gotoid', wid)
+            self._vim.command(r'execute "normal! \<C-b>"')
+            self._vim.call('win_gotoid', prev_id)
+        else:
+            self.scroll_up(self._winheight - 1)
 
     def scroll_page_forwards(self):
-        self.scroll_down(self._winheight - 1)
+        previewwindow = self.__get_preview_window()
+        if previewwindow:
+            prev_id = self._vim.call('win_getid')
+            wnr = previewwindow.number
+            wid = self._vim.call('win_getid', wnr)
+            self._vim.call('win_gotoid', wid)
+            self._vim.command(r'execute "normal! \<C-f>"')
+            self._vim.call('win_gotoid', prev_id)
+        else:
+            self.scroll_down(self._winheight - 1)
 
     def scroll_down(self, scroll):
         if self._win_cursor + self._cursor < self._candidates_len:


### PR DESCRIPTION
Attempt to fix #191.

Check previewwindow and bind scroll_page_backwards & scroll_page_forwards to previewwindow if  previewwindow exists.

This would make preview window more useful since denite prevent user change current window after open preview buffer.