### PR TITLE
Redirect subprocess stdin to devnull.

### DIFF
--- a/rplugin/python3/denite/process.py
+++ b/rplugin/python3/denite/process.py
@@ -18,6 +18,7 @@ class Process(object):
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         self.__proc = subprocess.Popen(commands,
+                                       stdin=subprocess.DEVNULL,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        startupinfo=startupinfo,


### PR DESCRIPTION
This is necessary on Windows to avoid the following error on `Denite
file_rec`:

```
[denite] Traceback (most recent call last):
[denite]   File "<string>", line 14, in _temporary_scope
[denite]   File "C:\Users\username\.vim\plugged\denite.nvim/rplugin/python3\denite\ui\default.py", line 103, in start
[denite]     self._denite.gather_candidates(self._context)
[denite]   File "C:\Users\username\.vim\plugged\denite.nvim/rplugin/python3\denite\denite.py", line 54, in gather_candidates
[denite]     candidates = source.gather_candidates(source.context)
[denite]   File "C:\Users\username\.vim\plugged\denite.nvim\rplugin/python3/denite\source\file_rec.py", line 71, in gather_candidates
[denite]     context['__proc'] = Process(args, context, directory)
[denite]   File "C:\Users\username\.vim\plugged\denite.nvim/rplugin/python3\denite\process.py", line 24, in __init__
[denite]     cwd=cwd)
[denite]   File "C:\Users\username\Miniconda3\Lib\subprocess.py", line 665, in __init__
[denite]     errread, errwrite) = self._get_handles(stdin, stdout, stderr)
[denite]   File "C:\Users\username\Miniconda3\Lib\subprocess.py", line 898, in _get_handles
[denite]     p2cread = self._make_inheritable(p2cread)
[denite]   File "C:\Users\username\Miniconda3\Lib\subprocess.py", line 948, in _make_inheritable
[denite]     _winapi.DUPLICATE_SAME_ACCESS)
[denite] OSError: [WinError 6] The handle is invalid
[denite] Please execute :messages command.
```

The error is due to the fact that stdin is indeed not a valid handle
(nothing is connected to it), see e.g.
http://stackoverflow.com/questions/40108816/python-running-as-windows-service-oserror-winerror-6-the-handle-is-invalid