### PR TITLE
fix interactive grep

### DIFF
--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -103,6 +103,7 @@ class Source(Base):
                 if arg == '!':
                     # Interactive mode
                     context['is_interactive'] = True
+                    arg = ''
                 else:
                     arg = [arg]
             elif not isinstance(arg, list):


### PR DESCRIPTION
Argument has to empty otherwise results are populated with files containing '!'.