### PR TITLE
RFC: modify jumplist before opening denite

### DIFF
--- a/autoload/denite.vim
+++ b/autoload/denite.vim
@@ -56,6 +56,13 @@ function! s:start(sources, user_context) abort
     return
   endif
 
+  call s:add_to_jumplist()
   return has('nvim') ? _denite_start(a:sources, context)
         \            : denite#vim#_start(a:sources, context)
+endfunction
+
+function! s:add_to_jumplist() abort
+  let mark_position = getpos("'a")
+  normal! ma`a
+  call setpos("'a", mark_position)
 endfunction


### PR DESCRIPTION
First, I think there is probably a better way to handle this, but I'm a bit of a vim/neovim newbie.

The problem is that denite is not adding the cursor position to the jumplist.  So if you run something like:

    :Denite outline
    (select a function in current file)
    (hit Ctrl-O to go back, discover that it takes you to some unexpectedly old jump)

This patch simply manually creates a jump in the jumplist by making a mark and jumping to it and then restoring the mark.  Kind of a hack, but a MASSIVE quality of life improvement in my opinion.  Any thoughts?