### PR TITLE
Ignore winrestcmd when resuming a suspended denite

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -139,6 +139,7 @@ class Default(object):
                 'win_gotoid', self._winid):
             # Move the window to bottom
             self._vim.command('wincmd J')
+            self._winrestcmd = ''
         else:
             # Create new buffer
             self._vim.call(


### PR DESCRIPTION
This fixes an easily recreated bug where the 'window' restore command is retrieved while the
denite window is open and upon finishing the denite action (and running this command) the remaining windows are "corrupted" (using far less rows than exist in the terminal).

How to recreate:

    :Denite file_rec
    " hit ctrl-z to suspend Denite
    " press enter to resume Denite
    " press enter again to open a file
    " screen is messed up.

