### PR TITLE
Make arguments required

### DIFF
--- a/plugin/denite.vim
+++ b/plugin/denite.vim
@@ -9,19 +9,19 @@ if exists('g:loaded_denite')
 endif
 let g:loaded_denite = 1
 
-command! -nargs=* -range -complete=customlist,denite#helper#complete
+command! -nargs=+ -range -complete=customlist,denite#helper#complete
       \ Denite
       \ call denite#helper#call_denite('Denite',
       \                                <q-args>, <line1>, <line2>)
-command! -nargs=* -range -complete=customlist,denite#helper#complete
+command! -nargs=+ -range -complete=customlist,denite#helper#complete
       \ DeniteCursorWord
       \ call denite#helper#call_denite('DeniteCursorWord',
       \                                <q-args>, <line1>, <line2>)
-command! -nargs=* -range -complete=customlist,denite#helper#complete
+command! -nargs=+ -range -complete=customlist,denite#helper#complete
       \ DeniteBufferDir
       \ call denite#helper#call_denite('DeniteBufferDir',
       \                                <q-args>, <line1>, <line2>)
-command! -nargs=* -range -complete=customlist,denite#helper#complete
+command! -nargs=+ -range -complete=customlist,denite#helper#complete
       \ DeniteProjectDir
       \ call denite#helper#call_denite('DeniteProjectDir',
       \                                <q-args>, <line1>, <line2>)


### PR DESCRIPTION
This avoids the error message `[denite] Empty sources` by making arguments required. New Error message is `E471: Argument required` which makes more clear that an additional argument is needed.

refereces vim-airline/vim-airline#1454