### PR TITLE
Define path in context dictionary before using it

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -46,6 +46,7 @@ function! denite#helper#call_denite(command, args, line1, line2) abort
   elseif a:command ==# 'DeniteBufferDir'
     let context.path = fnamemodify(bufname('%'), ':p:h')
   elseif a:command ==# 'DeniteProjectDir'
+    let context.path = ''
     let context.path = denite#util#path2project_directory(context.path)
   endif
 


### PR DESCRIPTION
Else this leads to an Error message, because the dictionary argument path is used before it is defined.