### PR TITLE
matcher_substring: simple substring-based filter

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1387,6 +1387,10 @@ matcher_ignore_globs
 matcher_regexp
 		A matcher which filters the candidates with user given
 		regular expression.
+						denite-filter-matcher_substring
+matcher_substring
+		A matcher which filters the candidates using simple substring
+		matching.
 
 						*denite-filter-sorter_rank*
 sorter_rank

--- a/rplugin/python3/denite/filter/matcher_substring.py
+++ b/rplugin/python3/denite/filter/matcher_substring.py
@@ -1,0 +1,35 @@
+# ============================================================================
+# FILE: matcher_substring.py
+# AUTHOR: Andrew Ruder <andy at aeruder.net>
+# License: MIT license
+# ============================================================================
+
+import re
+from .base import Base
+from denite.util import split_input
+
+class Filter(Base):
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'matcher_substring'
+        self.description = 'simple substring matcher'
+
+    def filter(self, context):
+        candidates = context['candidates']
+        ignorecase = context['ignorecase']
+        if context['input'] == '':
+            return candidates
+        max_width = context['max_candidate_width']
+        for pattern in split_input(context['input']):
+            if ignorecase:
+                pattern = pattern.lower()
+                candidates = [x for x in candidates
+                              if pattern in x['word'][:max_width].lower()]
+            else:
+                candidates = [x for x in candidates
+                              if pattern in x['word'][:max_width]]
+        return candidates
+
+    def convert_pattern(self, input_str):
+        return '\|'.join([re.escape(x) for x in split_input(input_str)])


### PR DESCRIPTION
matcher_substring is a simple substring-based filter.  As
a simple comparison between fuzzy and substring on this repository:

fuzzy:

    call denite#custom#source('file_rec', 'matchers', ['matcher_fuzzy'])
    Denite file_rec -input=process

    rplugin/python3/denite/process.py
    rplugin/python3/denite/prompt/docs/modules.rst
    rplugin/python3/denite/prompt/docs/requirements-docs.txt

substring:

    call denite#custom#source('file_rec', 'matchers', ['matcher_substring'])
    Denite file_rec -input=process

    rplugin/python3/denite/process.py

Like fuzzy, the input is split on spaces and each word is considered
individually.