### PR TITLE
outline: fix some error on windows

### DIFF
--- a/rplugin/python3/denite/source/outline.py
+++ b/rplugin/python3/denite/source/outline.py
@@ -52,6 +52,7 @@ class Source(Base):
             args += ['-o', tf.name]
             args += [context['__path']]
             self.print_message(context, args)
+            tf.close()
 
             try:
                 check_output(args).decode(self.vars['encoding'], 'replace')
@@ -59,7 +60,7 @@ class Source(Base):
                 return []
 
             candidates = []
-            with open(tf.name) as f:
+            with open(tf.name, encoding=self.vars['encoding']) as f:
                 for line in f:
                     if re.match('!', line) or not line:
                         continue


### PR DESCRIPTION
1. `tempfile.NamedTemporaryFile(mode='w')` will create and lock the temp file, so ctags can't write to that file.
2. the default encoding of `open` is not utf-8, so an error may occur when opening a utf-8 encoding file that generated by ctags