### PR TITLE
scantree can now run with python 2 as well

### DIFF
--- a/rplugin/python3/denite/scantree.py
+++ b/rplugin/python3/denite/scantree.py
@@ -29,7 +29,8 @@ try:
         for entry in scandir(path_name):
             if entry.is_dir(follow_symlinks=False):
                 if basename(entry.path) not in skip_list:
-                    yield from scantree(entry.path)
+                    for path in scantree(entry.path):
+                        yield path
             else:
                 yield entry.path
 except ImportError:


### PR DESCRIPTION
The "file_rec" source uses scantree.py on windows in a separate python process. The python used for this purpose is the first 'python' found in environment path. If this python does not support the 'yield from' syntax, the process will return throwing 'SyntaxError' exception and the denite buffer will be empty. 

From the original code it seems like that scantree.py is meant to support more python versions, therefore any subsequent drop in performance, although minimal, should be acceptable.