### PR TITLE
Make ctags file option customizable

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1216,7 +1216,7 @@ outline		Gather outline and jump to the target.
 				(default: ['ctags'])
 		options 	the default options for command
 				(default: [])
-		file_opt_name 	the default option name for writing to
+		file_opt 	the default option for writing to
 				specified file
 				(default: '-o')
 		ignore_types 	the list of ignore types

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1216,6 +1216,9 @@ outline		Gather outline and jump to the target.
 				(default: ['ctags'])
 		options 	the default options for command
 				(default: [])
+		file_opt_name 	the default option name for writing to
+				specified file
+				(default: '-o')
 		ignore_types 	the list of ignore types
 				(default: [])
 		encoding 	the text encoding

--- a/rplugin/python3/denite/source/outline.py
+++ b/rplugin/python3/denite/source/outline.py
@@ -27,7 +27,7 @@ class Source(Base):
         self.vars = {
             'command': ['ctags'],
             'options': [],
-            'file_opt_name': '-o',
+            'file_opt': '-o',
             'ignore_types': [],
             'encoding': 'utf-8'
         }
@@ -50,7 +50,7 @@ class Source(Base):
             args = []
             args += self.vars['command']
             args += self.vars['options']
-            args += [self.vars['file_opt_name'], tf.name]
+            args += [self.vars['file_opt'], tf.name]
             args += [context['__path']]
             self.print_message(context, args)
             tf.close()

--- a/rplugin/python3/denite/source/outline.py
+++ b/rplugin/python3/denite/source/outline.py
@@ -27,6 +27,7 @@ class Source(Base):
         self.vars = {
             'command': ['ctags'],
             'options': [],
+            'file_opt_name': '-o',
             'ignore_types': [],
             'encoding': 'utf-8'
         }
@@ -49,7 +50,7 @@ class Source(Base):
             args = []
             args += self.vars['command']
             args += self.vars['options']
-            args += ['-o', tf.name]
+            args += [self.vars['file_opt_name'], tf.name]
             args += [context['__path']]
             self.print_message(context, args)
             tf.close()


### PR DESCRIPTION
[jstemmer/gotags: ctags\-compatible tag generator for Go](https://github.com/jstemmer/gotags) supports only `-f` option for writing to specified file.
I want to use `-f` option instead of `-o` option or customize this option like this pull request.