### PR TITLE
Remove double negation in sentence in docs

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1768,9 +1768,9 @@ A: Python process was crashed.  I cannot fix the error.
 I think the process was under heavy load.  You should change
 |denite-options-updatetime| option.
 
-Q: hg(highway) does not work in denite.nvim?
+Q: Does hg (highway) work in denite.nvim?
 
-A: Yes.  It is not supported.
+A: No. It is not supported.
 
 ==============================================================================
 COMPATIBILITY						*denite-compatibility*


### PR DESCRIPTION
A double negation makes the dentence a little bit harder to understand.
If we invert the question, the answer turns out to be clearer.