### PR TITLE
Fix error when no custom sorters provided

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -300,9 +300,10 @@ class Default(object):
                 pattern = next(patterns, '')
 
         for sorter in self._context['sorters'].split(','):
-            ctx = copy(self._context)
-            ctx['candidates'] = self._candidates
-            self._candidates = self._denite.get_filter(sorter).filter(ctx)
+            if sorter:
+                ctx = copy(self._context)
+                ctx['candidates'] = self._candidates
+                self._candidates = self._denite.get_filter(sorter).filter(ctx)
 
         prev_matched_pattern = self._matched_pattern
         self._matched_pattern = pattern


### PR DESCRIPTION
When no `-sorters` provided, `get_filter` returns `None` and following error appears:
```
Traceback (most recent call last):
  File "denite.nvim/rplugin/python3/denite/__init__.py", line 33, in start
    return self._uis[buffer_name].start(args[0], args[1])
  File "denite.nvim/rplugin/python3/denite/ui/default.py", line 64, in start
    self._start(sources, context)
  File "denite.nvim/rplugin/python3/denite/ui/default.py", line 113, in _start
    self.update_candidates()
  File "denite.nvim/rplugin/python3/denite/ui/default.py", line 305, in update_candidates
    self._candidates = self._denite.get_filter(sorter).filter(ctx)
AttributeError: 'NoneType' object has no attribute 'filter'
```

Splitting an empty string will yield an empty match apparently.