### PR TITLE
Add ability to access/modify Denite context

### DIFF
--- a/autoload/denite/context.vim
+++ b/autoload/denite/context.vim
@@ -1,0 +1,24 @@
+"=============================================================================
+" FILE: context.vim
+" AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
+" License: MIT license
+"=============================================================================
+
+function! denite#context#get(...) abort
+  let key = a:0 ? a:1 : v:null
+  let bufname = a:0 > 1 ? a:2 : 'default'
+  if has('nvim')
+    return _denite_get_context(key, bufname)
+  else
+    return denite#vim#_get_context(key, bufname)
+  endif
+endfunction
+
+function! denite#context#set(key, value, ...) abort
+  let bufname = a:0 ? a:1 : 'default'
+  if has('nvim')
+    return _denite_set_context(a:key, a:value, bufname)
+  else
+    return denite#vim#_set_context(a:key, a:value, bufname)
+  endif
+endfunction

--- a/autoload/denite/context.vim
+++ b/autoload/denite/context.vim
@@ -10,6 +10,7 @@ function! denite#context#get(...) abort
   if has('nvim')
     return _denite_get_context(key, bufname)
   else
+    call denite#initialize()
     return denite#vim#_get_context(key, bufname)
   endif
 endfunction
@@ -19,6 +20,7 @@ function! denite#context#set(key, value, ...) abort
   if has('nvim')
     return _denite_set_context(a:key, a:value, bufname)
   else
+    call denite#initialize()
     return denite#vim#_set_context(a:key, a:value, bufname)
   endif
 endfunction

--- a/autoload/denite/vim.vim
+++ b/autoload/denite/vim.vim
@@ -54,3 +54,57 @@ if _temporary_scope in dir():
 EOF
   return []
 endfunction
+
+function! denite#vim#_get_context(key, bufname) abort
+  python3 << EOF
+def _temporary_scope():
+    global _value
+    import traceback
+    import vim
+    from denite.util import error
+    from denite.rplugin import Neovim, reform_bytes
+    nvim = Neovim(vim)
+    try:
+        if not denite__uis:
+            return
+        key = reform_bytes(nvim.eval('a:key'))
+        bufname = reform_bytes(nvim.eval('a:bufname'))
+        if key:
+            ui = denite__uis[reform_bytes(nvim.eval('a:bufname'))]
+            _value = ui._context[reform_bytes(nvim.eval('a:key'))]
+        else:
+            # Return list of keys of any UI
+            _value = sorted(next(iter(denite__uis.values()))._context)
+        nvim.command('return py3eval("_value")')
+    except Exception as e:
+        for line in traceback.format_exc().splitlines():
+            error(nvim, line)
+        error(nvim, 'Please execute :messages command.')
+_temporary_scope()
+if _temporary_scope in dir():
+    del _temporary_scope
+EOF
+endfunction
+
+function! denite#vim#_set_context(key, value, bufname) abort
+  python3 << EOF
+def _temporary_scope():
+    import traceback
+    import vim
+    from denite.util import error
+    from denite.rplugin import Neovim, reform_bytes
+    nvim = Neovim(vim)
+    try:
+        if not denite__uis:
+            return
+        ui = denite__uis[reform_bytes(nvim.eval('a:bufname'))]
+        ui._context[nvim.eval('a:key')] = reform_bytes(nvim.eval('a:value'))
+    except Exception as e:
+        for line in traceback.format_exc().splitlines():
+            error(nvim, line)
+        error(nvim, 'Please execute :messages command.')
+_temporary_scope()
+if _temporary_scope in dir():
+    del _temporary_scope
+EOF
+endfunction

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -894,6 +894,21 @@ denite#start({sources}[, {context}])
 		call denite#start([{'name': 'file_rec', 'args': []}])
 <
 
+denite#context#get([{key}, {bufname}])		    *denite#context#get()*
+		Retrieves variables from the context dictionary of a
+		Denite instance. With no arguments, returns a list of
+		variables contained in a context dictionary. With just
+		a key input, return the context value for the default
+		Denite instance. Optionally specify another Denite
+		instance with {bufname}.
+		Note: Returns nothing if no Denite buffer exists.
+
+denite#context#set({key}, {value}[, {bufname}])	    *denite#context#set()*
+		Sets the {value} of a variable {key} of context dictionary of
+		a Denite instance. Optionally specify a Denite buffer, or
+		else use the default Denite buffer.
+		Note: Does nothing if no Denite buffer exists.
+
 ------------------------------------------------------------------------------
 OPTIONS							*denite-options*
 

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -908,6 +908,25 @@ denite#context#set({key}, {value}[, {bufname}])	    *denite#context#set()*
 		a Denite instance. Optionally specify a Denite buffer, or
 		else use the default Denite buffer.
 		Note: Does nothing if no Denite buffer exists.
+>
+		" Create a map that toggles reverse order
+		function! ToggleReverse() abort " {{{
+		    let sorters = split(denite#context#get('sorters'), ',')
+		    if index(sorters, 'sorter_reverse') == -1
+		        call add(sorters, 'sorter_reverse')
+		    else
+		        call remove(sorters, index(sorters, 'sorter_reverse'))
+		    endif
+		    call denite#context#set('sorters', join(sorters, ','))
+		    return '<denite:redraw>'
+		endfunction " }}}
+		call denite#custom#map(
+		    \ 'insert',
+		    \ '<C-s>',
+		    \ 'ToggleReverse()',
+		    \ 'noremap expr'
+		    \)
+<
 
 ------------------------------------------------------------------------------
 OPTIONS							*denite-options*

--- a/rplugin/python3/denite/__init__.py
+++ b/rplugin/python3/denite/__init__.py
@@ -11,6 +11,7 @@ from importlib import find_loader
 if not find_loader('vim'):
     import neovim
     from denite.ui.default import Default
+    _uis = {}
 
     @neovim.plugin
     class DeniteHandlers(object):
@@ -19,7 +20,7 @@ if not find_loader('vim'):
 
         @neovim.function('_denite_init', sync=True)
         def init_python(self, args):
-            self._uis = {}
+            _uis.clear()
             self._vim.vars['denite#_channel_id'] = self._vim.channel_id
             return
 
@@ -28,10 +29,30 @@ if not find_loader('vim'):
             from denite.util import error
             try:
                 buffer_name = args[1]['buffer_name']
-                if buffer_name not in self._uis:
-                    self._uis[buffer_name] = Default(self._vim)
-                return self._uis[buffer_name].start(args[0], args[1])
+                if buffer_name not in _uis:
+                    _uis[buffer_name] = Default(self._vim)
+                return _uis[buffer_name].start(args[0], args[1])
             except Exception:
                 for line in traceback.format_exc().splitlines():
                     error(self._vim, line)
                 error(self._vim, 'Please execute :messages command.')
+
+        @neovim.function('_denite_get_context', sync=True)
+        def get_context(self, args):
+            key, bufname = args
+            if not _uis:
+                return
+            if key:
+                context = _uis[bufname]._context
+                return context[key]
+            else:
+                # Return list of keys of any UI
+                return sorted(next(iter(_uis.values()))._context)
+
+        @neovim.function('_denite_set_context', sync=True)
+        def set_context(self, args):
+            key, value, bufname = args
+            if not _uis:
+                return
+            context = _uis[bufname]._context
+            context[key] = value

--- a/rplugin/python3/denite/__init__.py
+++ b/rplugin/python3/denite/__init__.py
@@ -11,7 +11,7 @@ from importlib import find_loader
 if not find_loader('vim'):
     import neovim
     from denite.ui.default import Default
-    _uis = {}
+    _uis = {}  # type: dict
 
     @neovim.plugin
     class DeniteHandlers(object):

--- a/rplugin/python3/denite/filter/sorter_reverse.py
+++ b/rplugin/python3/denite/filter/sorter_reverse.py
@@ -1,0 +1,19 @@
+# ============================================================================
+# FILE: sorter_reverse.py
+# AUTHOR: Jacob Niehus <jacob.niehus at gmail.com>
+# DESCRIPTION: Simple filter to reverse the order of candidates
+# License: MIT license
+# ============================================================================
+from .base import Base
+
+
+class Filter(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'sorter_reverse'
+        self.description = 'reverse order of candidates'
+
+    def filter(self, context):
+        return list(reversed(context['candidates']))


### PR DESCRIPTION
This implements the ability to read/write to a Denite instance's context dictionary. I included (in the documentation I wrote but also below) an example that shows how to implement a key that reverses the order of candidates using only `denite#context#get`, `denite#context#set`, and `denite#custom#map`. I hope that shows how useful this can be.

```vim
function! ToggleReverse() abort " {{{
    let sorters = split(denite#context#get('sorters'), ',')
    if index(sorters, 'sorter_reverse') == -1
        call add(sorters, 'sorter_reverse')
    else
        call remove(sorters, index(sorters, 'sorter_reverse'))
    endif
    call denite#context#set('sorters', join(sorters, ','))
    return '<denite:redraw>'
endfunction " }}}
call denite#custom#map(
    \ 'insert',
    \ '<C-s>',
    \ 'ToggleReverse()',
    \ 'noremap expr'
    \)
```