### PR TITLE
Add new normal mode motions (zt, zz, zb, H, M, L, <C-E>, <C-Y>)

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -555,9 +555,17 @@ are on the neovim-prompt's builtin actions/mappings.
 <denite:scroll_window_downwards>
 		Scroll the window downwards.
 
+				*denite-map-scroll_window_down_one_line*
+<denite:scroll_window_down_one_line>
+		Scroll the window one line down like |CTRL-E|.
+
 				*denite-map-scroll_window_upwards*
 <denite:scroll_window_upwards>
 		Scroll the window upwards.
+
+				*denite-map-scroll_window_up_one_line*
+<denite:scroll_window_up_one_line>
+		Scroll the window one line up like |CTRL-E|.
 
 				*denite-map-scroll_page_forwards*
 <denite:scroll_page_forwards>
@@ -574,6 +582,18 @@ are on the neovim-prompt's builtin actions/mappings.
 				*denite-map-scroll_up*
 <denite:scroll_up>
 		Scroll up.
+
+				*denite-map-scroll_cursor_to_top*
+<denite:scroll_cursor_to_top>
+		Scroll the cursor to the top of the window like |zt|.
+
+				*denite-map-scroll_cursor_to_middle*
+<denite:scroll_cursor_to_middle>
+		Scroll the cursor to the middle of the window like |zz|.
+
+				*denite-map-scroll_cursor_to_bottom*
+<denite:scroll_cursor_to_bottom>
+		Scroll the cursor to the bottom of the window like |zb|.
 
 				*denite-map-toggle_insert_mode*
 <denite:toggle_insert_mode>
@@ -686,9 +706,14 @@ dd		<denite:delete_entire_text>
 gg		<denite:move_to_first_line>
 G		<denite:move_to_last_line>
 <C-U>		<denite:scroll_window_upwards>
+<C-E>		<denite:scroll_window_up_one_line>
 <C-D>		<denite:scroll_window_downwards>
+<C-Y>		<denite:scroll_window_down_one_line>
 <C-F>		<denite:scroll_page_forwards>
 <C-B>		<denite:scroll_page_backwards>
+zt		<denite:scroll_cursor_to_top>
+zz		<denite:scroll_cursor_to_middle>
+zb		<denite:scroll_cursor_to_bottom>
 p		<denite:do_action:preview>
 d		<denite:do_action:delete>
 n		<denite:do_action:new>

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -519,15 +519,15 @@ are on the neovim-prompt's builtin actions/mappings.
 
 				*denite-map-move_to_top*
 <denite:move_to_top>
-		Move to the top visible candidate.
+		Move to the top visible candidate like |H|.
 
 				*denite-map-move_to_middle*
 <denite:move_to_middle>
-		Move to the middle visible candidate.
+		Move to the middle visible candidate like |M|.
 
 				*denite-map-move_to_bottom*
 <denite:move_to_bottom>
-		Move to the bottom visible candidate.
+		Move to the bottom visible candidate like |L|.
 
 				*denite-map-paste_from_register*
 <denite:paste_from_register>

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -577,7 +577,7 @@ are on the neovim-prompt's builtin actions/mappings.
 
 				*denite-map-scroll_window_up_one_line*
 <denite:scroll_window_up_one_line>
-		Scroll the window one line up like |CTRL-E|.
+		Scroll the window one line up like |CTRL-Y|.
 
 				*denite-map-scroll_page_forwards*
 <denite:scroll_page_forwards>
@@ -734,7 +734,6 @@ n		<denite:do_action:new>
 t		<denite:do_action:tabopen>
 y		<denite:do_action:yank>
 q		<denite:quit>
-ZZ		<denite:quit>
 <C-L>		<denite:redraw>
 <C-R>		<denite:restart>
 <Space>		<denite:toggle_select_down>

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -517,6 +517,18 @@ are on the neovim-prompt's builtin actions/mappings.
 <denite:move_to_previous_line>
 		Move to previous line.
 
+				*denite-map-move_to_top*
+<denite:move_to_top>
+		Move to the top visible candidate.
+
+				*denite-map-move_to_middle*
+<denite:move_to_middle>
+		Move to the middle visible candidate.
+
+				*denite-map-move_to_bottom*
+<denite:move_to_bottom>
+		Move to the bottom visible candidate.
+
 				*denite-map-paste_from_register*
 <denite:paste_from_register>
 		Paste the text from a specified register.
@@ -705,6 +717,8 @@ cw		<denite:change_word>
 dd		<denite:delete_entire_text>
 gg		<denite:move_to_first_line>
 G		<denite:move_to_last_line>
+H		<denite:move_to_top>
+L		<denite:move_to_bottom
 <C-U>		<denite:scroll_window_upwards>
 <C-E>		<denite:scroll_window_up_one_line>
 <C-D>		<denite:scroll_window_downwards>
@@ -720,6 +734,7 @@ n		<denite:do_action:new>
 t		<denite:do_action:tabopen>
 y		<denite:do_action:yank>
 q		<denite:quit>
+ZZ		<denite:quit>
 <C-L>		<denite:redraw>
 <C-R>		<denite:restart>
 <Space>		<denite:toggle_select_down>

--- a/rplugin/python3/denite/ui/action.py
+++ b/rplugin/python3/denite/ui/action.py
@@ -27,6 +27,18 @@ def _move_to_previous_line(prompt, params):
     return prompt.denite.move_to_prev_line()
 
 
+def _move_to_top(prompt, params):
+    return prompt.denite.move_to_top()
+
+
+def _move_to_middle(prompt, params):
+    return prompt.denite.move_to_middle()
+
+
+def _move_to_bottom(prompt, params):
+    return prompt.denite.move_to_bottom()
+
+
 def _move_to_first_line(prompt, params):
     return prompt.denite.move_to_first_line()
 
@@ -244,6 +256,9 @@ DEFAULT_ACTION_RULES = [
     ('denite:move_to_last_line', _move_to_last_line),
     ('denite:move_to_next_line', _move_to_next_line),
     ('denite:move_to_previous_line', _move_to_previous_line),
+    ('denite:move_to_top', _move_to_top),
+    ('denite:move_to_middle', _move_to_middle),
+    ('denite:move_to_bottom', _move_to_bottom),
     ('denite:quit', _quit),
     ('denite:redraw', _redraw),
     ('denite:restart', _restart),
@@ -324,10 +339,12 @@ DEFAULT_ACTION_KEYMAP = {
         ('k', '<denite:move_to_previous_line>', 'noremap'),
         ('gg', '<denite:move_to_first_line>', 'noremap'),
         ('G', '<denite:move_to_last_line>', 'noremap'),
+        ('H', '<denite:move_to_top>', 'noremap'),
+        ('L', '<denite:move_to_bottom>', 'noremap'),
         ('<C-U>', '<denite:scroll_window_upwards>', 'noremap'),
-        ('<C-E>', '<denite:scroll_window_up_one_line>', 'noremap'),
+        ('<C-Y>', '<denite:scroll_window_up_one_line>', 'noremap'),
         ('<C-D>', '<denite:scroll_window_downwards>', 'noremap'),
-        ('<C-Y>', '<denite:scroll_window_down_one_line>', 'noremap'),
+        ('<C-E>', '<denite:scroll_window_down_one_line>', 'noremap'),
         ('<C-F>', '<denite:scroll_page_forwards>', 'noremap'),
         ('<C-B>', '<denite:scroll_page_backwards>', 'noremap'),
         ('zt', '<denite:scroll_cursor_to_top>', 'noremap'),

--- a/rplugin/python3/denite/ui/action.py
+++ b/rplugin/python3/denite/ui/action.py
@@ -39,8 +39,16 @@ def _scroll_window_upwards(prompt, params):
     return prompt.denite.scroll_window_upwards()
 
 
+def _scroll_window_up_one_line(prompt, params):
+    return prompt.denite.scroll_window_up_one_line()
+
+
 def _scroll_window_downwards(prompt, params):
     return prompt.denite.scroll_window_downwards()
+
+
+def _scroll_window_down_one_line(prompt, params):
+    return prompt.denite.scroll_window_down_one_line()
 
 
 def _scroll_page_forwards(prompt, params):
@@ -57,6 +65,18 @@ def _scroll_up(prompt, params):
 
 def _scroll_down(prompt, params):
     return prompt.denite.scroll_down(int(params))
+
+
+def _scroll_cursor_to_top(prompt, params):
+    return prompt.denite.scroll_cursor_to_top()
+
+
+def _scroll_cursor_to_middle(prompt, params):
+    return prompt.denite.scroll_cursor_to_middle()
+
+
+def _scroll_cursor_to_bottom(prompt, params):
+    return prompt.denite.scroll_cursor_to_bottom()
 
 
 def _jump_to_next_source(prompt, params):
@@ -232,7 +252,12 @@ DEFAULT_ACTION_RULES = [
     ('denite:scroll_page_forwards', _scroll_page_forwards),
     ('denite:scroll_up', _scroll_up),
     ('denite:scroll_window_downwards', _scroll_window_downwards),
+    ('denite:scroll_window_down_one_line', _scroll_window_down_one_line),
     ('denite:scroll_window_upwards', _scroll_window_upwards),
+    ('denite:scroll_window_up_one_line', _scroll_window_up_one_line),
+    ('denite:scroll_cursor_to_top', _scroll_cursor_to_top),
+    ('denite:scroll_cursor_to_middle', _scroll_cursor_to_middle),
+    ('denite:scroll_cursor_to_bottom', _scroll_cursor_to_bottom),
     ('denite:suspend', _suspend),
     ('denite:print_messages', _print_messages),
     ('denite:toggle_select', _toggle_select),
@@ -300,9 +325,14 @@ DEFAULT_ACTION_KEYMAP = {
         ('gg', '<denite:move_to_first_line>', 'noremap'),
         ('G', '<denite:move_to_last_line>', 'noremap'),
         ('<C-U>', '<denite:scroll_window_upwards>', 'noremap'),
+        ('<C-E>', '<denite:scroll_window_up_one_line>', 'noremap'),
         ('<C-D>', '<denite:scroll_window_downwards>', 'noremap'),
+        ('<C-Y>', '<denite:scroll_window_down_one_line>', 'noremap'),
         ('<C-F>', '<denite:scroll_page_forwards>', 'noremap'),
         ('<C-B>', '<denite:scroll_page_backwards>', 'noremap'),
+        ('zt', '<denite:scroll_cursor_to_top>', 'noremap'),
+        ('zz', '<denite:scroll_cursor_to_middle>', 'noremap'),
+        ('zb', '<denite:scroll_cursor_to_bottom>', 'noremap'),
         ('q', '<denite:quit>', 'noremap'),
         ('<C-L>', '<denite:redraw>', 'noremap'),
         ('<C-R>', '<denite:restart>', 'noremap'),

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -186,6 +186,7 @@ class Default(object):
         self._window_options['conceallevel'] = 3
         self._window_options['concealcursor'] = 'n'
         self._window_options['list'] = False
+        self._window_options['wrap'] = False
 
         self._bufvars = self._vim.current.buffer.vars
         self._bufnr = self._vim.current.buffer.number
@@ -651,7 +652,9 @@ class Default(object):
 
     def scroll_down(self, scroll):
         if self._win_cursor + self._cursor < self._candidates_len:
-            if self._win_cursor < self._winheight:
+            if self._win_cursor == 1:
+                self._cursor -= scroll
+            elif self._win_cursor < self._winheight:
                 self._win_cursor = min(
                     self._win_cursor + scroll,
                     self._candidates_len,
@@ -672,6 +675,35 @@ class Default(object):
         else:
             return
         self.update_cursor()
+
+    def scroll_window_up_one_line(self):
+        if self._cursor < 1:
+            return self.scroll_up(1)
+        self._cursor -= 1
+        self._win_cursor += 1
+        self.update_cursor()
+
+    def scroll_window_down_one_line(self):
+        if self._win_cursor <= 1:
+            return self.scroll_down(1)
+        self._cursor += 1
+        self._win_cursor -= 1
+        self.update_cursor()
+
+    def scroll_cursor_to_top(self):
+        self._cursor += self._win_cursor - 1
+        self._win_cursor = 1
+        self.update_cursor()
+
+    def scroll_cursor_to_middle(self):
+        self.scroll_cursor_to_top()
+        while self._cursor >= 1 and self._win_cursor < self._winheight // 2:
+            self.scroll_window_up_one_line()
+
+    def scroll_cursor_to_bottom(self):
+        self.scroll_cursor_to_top()
+        while self._cursor >= 1 and self._win_cursor < self._winheight:
+            self.scroll_window_up_one_line()
 
     def jump_to_next_source(self):
         if len(self._context['sources']) == 1:

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -638,6 +638,18 @@ class Default(object):
             self._cursor = cur_max
             self.update_cursor()
 
+    def move_to_top(self):
+        self._win_cursor = 1
+        self.update_cursor()
+
+    def move_to_middle(self):
+        self._win_cursor = self._winheight // 2
+        self.update_cursor()
+
+    def move_to_bottom(self):
+        self._win_cursor = self._winheight
+        self.update_cursor()
+
     def scroll_window_upwards(self):
         self.scroll_up(self._scroll)
 

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -664,8 +664,10 @@ class Default(object):
 
     def scroll_down(self, scroll):
         if self._win_cursor + self._cursor < self._candidates_len:
-            if self._win_cursor == 1:
-                self._cursor -= scroll
+            if self._win_cursor <= 1:
+                self._win_cursor = 1
+                self._cursor = min(self._cursor + scroll,
+                                   self._candidates_len)
             elif self._win_cursor < self._winheight:
                 self._win_cursor = min(
                     self._win_cursor + scroll,
@@ -696,7 +698,7 @@ class Default(object):
         self.update_cursor()
 
     def scroll_window_down_one_line(self):
-        if self._win_cursor <= 1:
+        if self._win_cursor <= 1 and self._cursor > 0:
             return self.scroll_down(1)
         self._cursor += 1
         self._win_cursor -= 1


### PR DESCRIPTION
This implements more normal mode motions that I use regularly. Specifically, it implements `zt`, `zz`, `zb`, `H`, `M`, `L`, `<C-E>`, and `<C-Y>`. I tested the edge cases, but do check my work :).

I did not bind `M` to `<denite:move_to_middle>` because `M` is already being used for `<denite:print_messages>`.