### PR TITLE
Add more normal mode actions (S, s, x)

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -341,11 +341,6 @@ are on the neovim-prompt's builtin actions/mappings.
 <denite:change_char>
 		Change character like |s| in normal mode in vim buffer.
 
-				*denite-map-delete_char_under_caret*
-<denite:delete_char_under_caret>
-		Delete the character under the caret like |x| in normal mode
-		in vim buffer.
-
 				*denite-map-change_path*
 <denite:change_path>
 		Change and restart Denite buffer.

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -337,6 +337,15 @@ are on the neovim-prompt's builtin actions/mappings.
 <denite:change_line>
 		Change line, like |cc| in normal mode in vim buffer.
 
+				*denite-map-change_char*
+<denite:change_char>
+		Change character like |s| in normal mode in vim buffer.
+
+				*denite-map-delete_char_under_caret*
+<denite:delete_char_under_caret>
+		Delete the character under the caret like |x| in normal mode
+		in vim buffer.
+
 				*denite-map-change_path*
 <denite:change_path>
 		Change and restart Denite buffer.
@@ -681,6 +690,9 @@ e		<denite:move_caret_to_end_of_word>
 $		<denite:move_caret_to_tail>
 c		<denite:change_word>
 cc		<denite:change_line>
+S		<denite:change_line>
+s		<denite:change_char>
+x		<denite:delete_char_under_caret>
 cw		<denite:change_word>
 dd		<denite:delete_entire_text>
 gg		<denite:move_to_first_line>

--- a/rplugin/python3/denite/ui/action.py
+++ b/rplugin/python3/denite/ui/action.py
@@ -176,6 +176,14 @@ def _change_line(prompt, params):
     prompt.denite.change_mode('insert')
 
 
+def _change_char(prompt, params):
+    prompt.text = ''.join([
+        prompt.caret.get_backward_text(),
+        prompt.caret.get_forward_text(),
+    ])
+    prompt.denite.change_mode('insert')
+
+
 def _move_caret_to_next_word(prompt, params):
     pattern = re.compile('^\S+\s+\S')
     original_text = prompt.caret.get_forward_text()
@@ -243,6 +251,7 @@ DEFAULT_ACTION_RULES = [
     ('denite:move_caret_to_end_of_word', _move_caret_to_end_of_word),
     ('denite:change_word', _change_word),
     ('denite:change_line', _change_line),
+    ('denite:change_char', _change_char),
     ('denite:append', _append),
     ('denite:append_to_line', _append_to_line),
     ('denite:insert_to_head', _insert_to_head),
@@ -316,7 +325,11 @@ DEFAULT_ACTION_KEYMAP = {
         ('0', '<denite:move_caret_to_head>', 'noremap'),
         ('$', '<denite:move_caret_to_tail>', 'noremap'),
         ('cc', '<denite:change_line>', 'noremap'),
+        ('S', '<denite:change_line>', 'noremap'),
         ('cw', '<denite:change_word>', 'noremap'),
+        ('S', '<denite:change_line>', 'noremap'),
+        ('s', '<denite:change_char>', 'noremap'),
+        ('x', '<denite:delete_char_under_caret>', 'noremap'),
         ('dd', '<denite:delete_entire_text>', 'noremap'),
         ('h', '<denite:move_caret_to_left>', 'noremap'),
         ('l', '<denite:move_caret_to_right>', 'noremap'),


### PR DESCRIPTION
Add an `S` map for `<denite:change_line>` and add actions `<denite:change_char>` nmapped to `s` and `<denite:delete_char_under_caret>` nmapped to `x`.