### PR TITLE
Fix reference to non-existent function

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -298,7 +298,7 @@ class Default(object):
             for sorter in self._context['sorters'].split(','):
                 ctx = copy(self._context)
                 ctx['candidates'] = self._candidates
-                self._candidates = self._denite.get_filter(sorter).filter(ctx)
+                self._candidates = self._denite._filters[sorter].filter(ctx)
 
         if self._context['unique']:
             unique_candidates = []


### PR DESCRIPTION
A function called `get_filter` is called in default.py but has no implementation. This just fixes it by using `self._default._filters`. This fixes #325.