### PR TITLE
Quit if -quit is on command line even if action is not is_quit

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -38,6 +38,7 @@ endfunction
 function! denite#helper#call_denite(command, args, line1, line2) abort
   let [args, context] = denite#helper#_parse_options_args(a:args)
 
+  let context.force_quit = get(context, 'quit', v:false)
   let context.firstline = a:line1
   let context.lastline = a:line2
   let context.bufnr = bufnr('%')

--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -38,7 +38,6 @@ endfunction
 function! denite#helper#call_denite(command, args, line1, line2) abort
   let [args, context] = denite#helper#_parse_options_args(a:args)
 
-  let context.force_quit = get(context, 'quit', v:false)
   let context.firstline = a:line1
   let context.lastline = a:line2
   let context.bufnr = bufnr('%')

--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -94,6 +94,7 @@ function! denite#init#_user_options() abort
         \ 'prompt': '#',
         \ 'prompt_highlight': 'Statement',
         \ 'quit': v:true,
+        \ 'force_quit': v:false,
         \ 'refresh': v:false,
         \ 'resume': v:false,
         \ 'reversed': v:false,

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1085,6 +1085,12 @@ OPTIONS							*denite-options*
 		Quit the denite buffer after the action is executed.
 		Default: true
 
+						*denite-options-force-quit*
+-force-quit
+		Quit the denite buffer after the action is executed even if
+		the action causes quit.
+		Default: false
+
 						*denite-options-refresh*
 -refresh
 		Refresh the candidates when |denite-options-resume| is true.

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -79,8 +79,8 @@ class Default(object):
             # Skip the initialization
             if context['mode']:
                 self._current_mode = context['mode']
-            self._context['immediately'] = context['immediately']
-            self._context['cursor_wrap'] = context['cursor_wrap']
+            for key in 'immediately', 'cursor_wrap', 'cursor_pos', 'quit':
+                self._context[key] = context[key]
 
             if self.check_empty():
                 return
@@ -580,7 +580,7 @@ class Default(object):
             self._context, action_name, candidates)
         if not action:
             return
-        is_quit = action['is_quit']
+        is_quit = action['is_quit'] or self._context['force_quit']
         if is_quit:
             self.quit()
 

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -79,7 +79,8 @@ class Default(object):
             # Skip the initialization
             if context['mode']:
                 self._current_mode = context['mode']
-            for key in 'immediately', 'cursor_wrap', 'cursor_pos', 'quit':
+            update = 'immediately', 'cursor_wrap', 'cursor_pos', 'force_quit'
+            for key in update:
                 self._context[key] = context[key]
 
             if self.check_empty():


### PR DESCRIPTION
This is useful for using `-immediately` for actions that don't quit denite.nvim. For example, my grep is not `is_quit`, so when I run `:Denite -resume -immediately -quit` it opens the denite window and it stays open despite having the `-quit` in the command line.

Basically, this allows non-`is_quit` actions to be selected using `-cursor-pos` but still keep denite closed after the action.