### PR TITLE
Fix document

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1390,7 +1390,7 @@ outline		Gather outline and jump to the target.
 		encoding 	the text encoding
 				(default: 'utf-8')
 
-						*unite-source-output*
+						*denite-source-output*
 output		Gather executed command output as candidates.
 
 		Source arguments:


### PR DESCRIPTION
Fix following error.

```
[dein] Error generating helptags:
[dein] Vim(helptags):E154: Duplicate tag "unite-source-output" in file /Users/pocari/.cache/dein/.cache/init.vim/.dein/doc/unite.txt
[dein] function dein#recache_runtimepath[1]..dein#install#_recache_runtimepath[20]..<SNR>70_helptags, line 12
```
