### PR TITLE
Add a feature to jump to next result in different file in grep source (and more!)

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -441,6 +441,20 @@ are on the neovim-prompt's builtin actions/mappings.
 >
 		call denite#custom#map('insert', '<F4>', 'hello!', 'noremap')
 <
+				*denite-map-jump_to_next_by*
+<denite:jump_to_next_by:{word}>
+		Jump to the next candidate with a different value of {word}.
+		For example,
+>
+		<denite:jump_to_next_by:path>
+<
+		will jump to the next result in a different file in grep.
+
+				*denite-map-jump_to_previous_by*
+<denite:jump_to_previous_by:{word}>
+		Jump to the previous candidate with a different value of
+		{word}.
+
 				*denite-map-jump_to_next_source*
 <denite:jump_to_next_source>
 		Jump to the first candidate of the next source.

--- a/rplugin/python3/denite/ui/action.py
+++ b/rplugin/python3/denite/ui/action.py
@@ -108,12 +108,20 @@ def _scroll_cursor_to_bottom(prompt, params):
     return prompt.denite.scroll_cursor_to_bottom()
 
 
+def _jump_to_next_by(prompt, params):
+    return prompt.denite.jump_to_next_by(params)
+
+
+def _jump_to_previous_by(prompt, params):
+    return prompt.denite.jump_to_prev_by(params)
+
+
 def _jump_to_next_source(prompt, params):
-    return prompt.denite.jump_to_next_source()
+    return prompt.denite.jump_to_next_by('source')
 
 
 def _jump_to_previous_source(prompt, params):
-    return prompt.denite.jump_to_prev_source()
+    return prompt.denite.jump_to_prev_by('source')
 
 
 def _input_command_line(prompt, params):
@@ -274,6 +282,8 @@ DEFAULT_ACTION_RULES = [
     ('denite:enter_mode', _enter_mode),
     ('denite:input_command_line', _input_command_line),
     ('denite:insert_word', _insert_word),
+    ('denite:jump_to_next_by', _jump_to_next_by),
+    ('denite:jump_to_previous_by', _jump_to_previous_by),
     ('denite:jump_to_next_source', _jump_to_next_source),
     ('denite:jump_to_previous_source', _jump_to_previous_source),
     ('denite:leave_mode', _leave_mode),


### PR DESCRIPTION
I was missing being able to jump between files in grep results (very useful when there may be 50 results in one file) so I decided to add the feature. I made it general enough to be useful for other purposes, i.e. it can jump grouping by any attribute a candidate might have.

This example shows how to make `gj` and `gk` select between file groups instead of single candidates:

```vim
call denite#custom#map('normal', 'gj', '<denite:jump_to_next_by:path>')
call denite#custom#map('normal', 'gk', '<denite:jump_to_previous_by:path>')
```