### PR TITLE
[RFC] allow quoted source arguments (ex. source:"!rg foobar" instead of source:!rg:foobar)

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -262,12 +262,14 @@ COMMANDS 						*denite-commands*
 
 		Denite can accept a list of strings, separated with ":", after
 		the name of sources.  You must escape ":" and "\" with "\"
-		in parameters themselves.
+		in parameters themselves, or surround the parameter with quotes.
 
 		Examples:
 		"file_rec:foo:bar": the parameters of source file are
 		                    ["foo", "bar"].
 		"file_rec:foo\:bar": the parameter of source file is
+		                     ["foo:bar"].
+		"file_rec:'foo:bar'": the parameter of source file is
 		                     ["foo:bar"].
 		"file_rec:foo::bar": the parameters of source file are
 		                     ["foo", "", "bar"].


### PR DESCRIPTION
There are still some problems to fix, but I want to find out if this feature is desirable before I spend more time on it.