### PR TITLE
Detect validly non-windows env

### DIFF
--- a/rplugin/python3/denite/filter/matcher_cpsm.py
+++ b/rplugin/python3/denite/filter/matcher_cpsm.py
@@ -28,7 +28,7 @@ class Filter(Base):
 
         if not self.__initialized:
             # cpsm installation check
-            ext = '.pyd' if context['is_windows'] else '.so'
+            ext = '.pyd' if context['is_windows'] != '0' else '.so'
             if globruntime(context['runtimepath'], 'bin/cpsm_py' + ext):
                 # Add path
                 sys.path.append(os.path.dirname(

--- a/rplugin/python3/denite/source/line.py
+++ b/rplugin/python3/denite/source/line.py
@@ -48,12 +48,13 @@ class Source(Base):
         linenr = context['__linenr']
         candidates = []
         for bufnr in context['__bufnrs']:
-            lines = [{'word': x,
-                    'abbr': (context['__fmt'] % (i + 1, x)),
-                    'action__path': self.vim.call('bufname', bufnr),
-                    'action__line': (i + 1)}
-                    for [i, x] in
-                    enumerate(self.vim.call('getbufline', bufnr, 1, '$'))]
+            lines = [{
+                'word': x,
+                'abbr': (context['__fmt'] % (i + 1, x)),
+                'action__path': self.vim.call('bufname', bufnr),
+                'action__line': (i + 1)}
+                for [i, x] in
+                enumerate(self.vim.call('getbufline', bufnr, 1, '$'))]
             if context['__direction'] == 'all':
                 candidates += lines
             elif context['__direction'] == 'backward':

--- a/rplugin/python3/denite/source/line.py
+++ b/rplugin/python3/denite/source/line.py
@@ -29,7 +29,7 @@ class Source(Base):
         context['__direction'] = 'all'
         context['__fmt'] = '%' + str(len(
             str(self.vim.call('line', '$')))) + 'd: %s'
-        if context['args'] :
+        if context['args']:
             direction = context['args'][0]
             if (direction == 'all' or direction == 'forward' or
                     direction == 'backward'):


### PR DESCRIPTION
because `context['is_windows']` may have `'0'` string that is truthy

I found this with MacVim 8.0.771 + Python3 3.6.2 (homebrew)