### PR TITLE
Make the buffer source filterable

### DIFF
--- a/rplugin/python3/denite/source/buffer.py
+++ b/rplugin/python3/denite/source/buffer.py
@@ -73,7 +73,7 @@ class Source(Base):
     def _convert(self, buffer_attr, rjust):
         if buffer_attr['name'] == '':
             name = 'No Name'
-            path = None
+            path = ''
         else:
             name = self.vim.call('fnamemodify', buffer_attr['name'], ':~:.')
             path = self.vim.call('fnamemodify', buffer_attr['name'], ':p')

--- a/rplugin/python3/denite/source/buffer.py
+++ b/rplugin/python3/denite/source/buffer.py
@@ -71,9 +71,12 @@ class Source(Base):
         return False
 
     def _convert(self, buffer_attr, rjust):
-        name = self.vim.call(
-            'fnamemodify', buffer_attr['name'], ':~:.'
-        ) if buffer_attr['name'] != '' else 'No Name'
+        if buffer_attr['name'] == '':
+            name = 'No Name'
+            path = None
+        else:
+            name = self.vim.call('fnamemodify', buffer_attr['name'], ':~:.')
+            path = self.vim.call('fnamemodify',buffer_attr['name'],':p')
         return {
             'bufnr': buffer_attr['number'],
             'word': name,
@@ -88,6 +91,7 @@ class Source(Base):
                          ) if self.vars['date_format'] != '' else ''
             ),
             'action__bufnr': buffer_attr['number'],
+            'action__path': path,
             'timestamp': buffer_attr['timestamp']
         }
 

--- a/rplugin/python3/denite/source/buffer.py
+++ b/rplugin/python3/denite/source/buffer.py
@@ -76,7 +76,7 @@ class Source(Base):
             path = None
         else:
             name = self.vim.call('fnamemodify', buffer_attr['name'], ':~:.')
-            path = self.vim.call('fnamemodify',buffer_attr['name'],':p')
+            path = self.vim.call('fnamemodify', buffer_attr['name'], ':p')
         return {
             'bufnr': buffer_attr['number'],
             'word': name,


### PR DESCRIPTION
Just include the full file path for each buffer as `action__path`, if it exists. Otherwise, set it as `None`.

This is consistent with other sources and allows filtering in the buffer list.

My use case is restricting buffers to a project directory. So I use:
```vim
call denite#custom#alias('source', 'project/buffer', 'buffer')
call denite#custom#source('project/buffer', 'matchers',
			\ ['matcher_project_files', 'matcher_fuzzy'] )
```