### PR TITLE
Fix file finding on Windows.

### DIFF
--- a/rplugin/python3/denite/kind/directory.py
+++ b/rplugin/python3/denite/kind/directory.py
@@ -5,6 +5,7 @@
 # License: MIT license
 # ============================================================================
 
+from os.path import sep as PATH_SEP
 from .base import Base
 
 
@@ -25,8 +26,8 @@ class Kind(Base):
     def action_narrow(self, context):
         target = context['targets'][0]
         context['input'] = target['action__path']
-        if context['input'][-1] != '/':
-            context['input'] += '/'
+        if context['input'][-1] != PATH_SEP:
+            context['input'] += PATH_SEP
 
     def action_open(self, context):
         for target in context['targets']:


### PR DESCRIPTION
Fixes issue #376. The problem was that Denite uses '/' as its path 
separator on all platforms, which doesn't work (for some reason) on 
Windows.  This fixes by using `os.path.sep` instead of a literal 
forward-slash.