### PR TITLE
parse_tagline: return None when unparseable

### DIFF
--- a/rplugin/python3/denite/source/outline.py
+++ b/rplugin/python3/denite/source/outline.py
@@ -68,6 +68,8 @@ class Source(Base):
                     if re.match('!', line) or not line:
                         continue
                     info = parse_tagline(line.rstrip(), tf.name)
+                    if not info:
+                        continue
                     if info['type'] in self.vars['ignore_types']:
                         continue
 

--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -195,7 +195,7 @@ def parse_tagline(line, tagpath):
     rest = '\t'.join(elem[2:])
     m = re.search(r'.*;"', rest)
     if not m:
-        return {}
+        return None
 
     pattern = m.group(0)
     if re.match('\d+;"$', pattern):


### PR DESCRIPTION
I accidentally got emacs ctags in my path and it made a mess of some
tags files for perl causing denite to be unable to parse.

=== RIGHT NOW ===
parse_tagline returns {} when it fails:

    source/tag.py assumed that parse_tagline would be returning None when
    the parse failed.

    source/outline.py assumed it would always succeed and only went on
    to get KeyError's when the 'type' field wasn't filled in.

=== AFTER THIS CHANGE ===
Changing parse_tagline to return None on failure:

    source/tag.py already copes with it correctly

    source/outline.py updated to continue if None