### PR TITLE
Detect Haskell projects via stack.yaml file

### DIFF
--- a/autoload/denite/util.vim
+++ b/autoload/denite/util.vim
@@ -141,7 +141,7 @@ function! denite#util#path2project_directory(path, ...) abort
   if directory ==# ''
     for d in ['build.xml', 'prj.el', '.project', 'pom.xml', 'package.json',
           \ 'Makefile', 'configure', 'Rakefile', 'NAnt.build',
-          \ 'P4CONFIG', 'tags', 'gtags']
+          \ 'P4CONFIG', 'tags', 'gtags', 'stack.yaml']
       let d = findfile(d, s:escape_file_searching(search_directory) . ';')
       if d !=# ''
         let directory = fnamemodify(d, ':p:h')


### PR DESCRIPTION
Haskell projects commonly use Stack for building Haskell software. The presence of `stack.yaml` indicates a project root directory (see: https://docs.haskellstack.org/en/stable/yaml_configuration/).