### PR TITLE
Remove breaking empty argument in `rg` usage

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -123,7 +123,7 @@ EXAMPLES						*denite-examples*
 	" For ripgrep
 	" Note: It is slower than ag
 	call denite#custom#var('file_rec', 'command',
-	\ ['rg', '--files', '--glob', '!.git', ''])
+	\ ['rg', '--files', '--glob', '!.git'])
 	" For Pt(the platinum searcher)
 	" NOTE: It also supports windows.
 	call denite#custom#var('file_rec', 'command',


### PR DESCRIPTION
This suggested usage results in the following error:

    [denite] file_rec: : No such file or directory (os error 2)

/see #393