### PR TITLE
Fixed delete key behaving as left key (#431)

### DIFF
--- a/rplugin/python3/denite/ui/prompt.py
+++ b/rplugin/python3/denite/ui/prompt.py
@@ -90,11 +90,10 @@ class DenitePrompt(Prompt):
         if m:
             bufvars = self.denite._bufvars
             bufvars['denite_context'] = self.context
-            ret = self.action.call(self, m.group('action'))
             if bufvars['denite_context'] != self.context:
                 # Update context
                 self.context = bufvars['denite_context']
-            return ret
+            return self.action.call(self, m.group('action'))
         elif self.denite.current_mode == 'insert':
             # Updating text from a keystroke is a feature of 'insert' mode
             self.update_text(str(keystroke))


### PR DESCRIPTION
After some hunting, and the tip of @petobens that this bug happend after the last two commits, I found this. Directly returning the action call seems to fix the issue of not being able to backspace in the search field.