### PR TITLE
Improve statusline object

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -997,7 +997,11 @@ denite#get_status({name})				*denite#get_status()*
 		"mode": Current mode
 		"sources": Current sources and candidates number
 		"path": Specified |denite-options-path|
-		"linenr": Current line number
+		"linenr": Equivalent to "line_cursor/line_total"
+		"raw_mode": Current mode, without any processing
+		"buffer_name": Current |denite-options-buffer-name|
+		"line_cursor": Cursor position. Part of "linenr".
+		"line_total": Total candidates. Part of "linenr".
 
 denite#get_status_mode()			 *denite#get_status_mode()*
 		Please use |denite#get_status()| instead.

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -58,7 +58,7 @@ class Default(object):
             weakref.proxy(self)
         )
         self._guicursor = ''
-        self._prev_status = ''
+        self._prev_status = {}
         self._prev_curpos = []
         self._is_suspend = False
         self._save_window_options = {}
@@ -142,7 +142,7 @@ class Default(object):
         return
 
     def init_buffer(self):
-        self._prev_status = ''
+        self._prev_status = dict()
         self._displayed_texts = []
 
         if not self._is_suspend:
@@ -405,23 +405,30 @@ class Default(object):
         self.move_cursor()
 
     def update_status(self):
+        raw_mode = self._current_mode.upper()
+        cursor_location = self._cursor + self._win_cursor
         max_len = len(str(self._candidates_len))
         linenr = ('{:'+str(max_len)+'}/{:'+str(max_len)+'}').format(
-            self._cursor + self._win_cursor,
+            cursor_location,
             self._candidates_len)
-        mode = '-- ' + self._current_mode.upper() + ' -- '
+        mode = '-- ' + raw_mode + ' -- '
         if self._context['error_messages']:
             mode = '[ERROR] ' + mode
         path = '[' + self._context['path'] + ']'
 
-        status = mode + self._statusline_sources + path + linenr
+        status = {
+            'mode': mode,
+            'sources': self._statusline_sources,
+            'path': path,
+            'linenr': linenr,
+            # Extra
+            'raw_mode': raw_mode,
+            'buffer_name': self._context['buffer_name'],
+            'line_cursor': cursor_location,
+            'line_total': self._candidates_len,
+        }
         if status != self._prev_status:
-            st_vars = {}
-            st_vars['mode'] = mode
-            st_vars['sources'] = self._statusline_sources
-            st_vars['path'] = path
-            st_vars['linenr'] = linenr
-            self._bufvars['denite_statusline'] = st_vars
+            self._bufvars['denite_statusline'] = status
             self._vim.command('redrawstatus')
             self._prev_status = status
 


### PR DESCRIPTION
This extends the statusline object `b:denite_statusline` with more
parameters (like `buffer_name`) and includes "raw" versions of existing
arguments.
The existing arguments are kept for backwards compatibility.

This should make it easire to configure custom statusline functions.

Related to #407