### PR TITLE
Use os.walk instead to support Py 3.4

### DIFF
--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -201,24 +201,29 @@ def find_rplugins(context, source, loaded_paths):
     """
     base = join('rplugin', 'python3', 'denite', source)
     for runtime in context.get('runtimepath', '').split(','):
-        root = os.path.normpath(join(runtime, base))
-        for path in filter(lambda p: normcase(normpath(p)) not in loaded_paths,
-                           iglob(join(root, '**', '*.py'), recursive=True)):
-            module_path = os.path.relpath(str(path), root)
-            module_path = os.path.splitext(module_path)[0]
-            if module_path == '__init__':
-                # __init__.py in {root} does not have implementation so skip
-                continue
-            elif module_path == 'base' and source != 'kind':
-                # base.py in {root} does not have implementation so skip
-                # NOTE: kind/base.py DOES have implementation so do NOT skip
-                continue
-            if os.path.basename(module_path) == '__init__':
-                # 'foo/__init__.py' should be loaded as a module 'foo'
-                module_path = os.path.dirname(module_path)
-            # Convert IO path to module path
-            module_path = module_path.replace(os.sep, '.')
-            yield (path, module_path)
+        root = normcase(normpath(join(runtime, base)))
+        for r, _, fs in os.walk(root):
+            for f in fs:
+                path = normcase(normpath(join(r, f)))
+                if not path.endswith('.py') or path in loaded_paths:
+                    continue
+                module_path = os.path.relpath(path, root)
+                module_path = os.path.splitext(module_path)[0]
+                if module_path == '__init__':
+                    # __init__.py in {root} does not have implementation
+                    # so skip
+                    continue
+                elif module_path == 'base' and source != 'kind':
+                    # base.py in {root} does not have implementation so skip
+                    # NOTE: kind/base.py DOES have implementation so do
+                    # NOT skip
+                    continue
+                if os.path.basename(module_path) == '__init__':
+                    # 'foo/__init__.py' should be loaded as a module 'foo'
+                    module_path = os.path.dirname(module_path)
+                # Convert IO path to module path
+                module_path = module_path.replace(os.sep, '.')
+                yield (path, module_path)
 
 
 def import_rplugins(name, context, source, loaded_paths):

--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -8,7 +8,7 @@ import re
 import os
 import sys
 
-from glob import glob, iglob
+from glob import glob
 from os.path import normpath, normcase, join, dirname
 from importlib.machinery import SourceFileLoader
 

--- a/test/rplugin/python3/denite/test_util.py
+++ b/test/rplugin/python3/denite/test_util.py
@@ -66,9 +66,9 @@ def test_parse_tag_line():
         }
 
 
-@patch('denite.util.iglob')
-def test_find_rplugins_source(iglob):
-    iglob.side_effect = _iglob_side_effect
+@patch('denite.util.os.walk')
+def test_find_rplugins_source(walk):
+    walk.side_effect = _walk_side_effect
 
     context = { 'runtimepath': '/a,/b' }
     source = 'source'
@@ -79,41 +79,40 @@ def test_find_rplugins_source(iglob):
     )]
 
     it = util.find_rplugins(context, source, loaded_paths)
-    iglob.assert_not_called()
+    walk.assert_not_called()
 
     assert next(it) == ('/a/%s/foo.py' % prefix, 'foo')
     assert next(it) == ('/a/%s/bar/__init__.py' % prefix, 'bar')
-    assert next(it) == ('/a/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/a/%s/bar/foo.py' % prefix, 'bar.foo')
+    assert next(it) == ('/a/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/a/%s/bar/hoge/__init__.py' % prefix, 'bar.hoge')
-    assert next(it) == ('/a/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
     assert next(it) == ('/a/%s/bar/hoge/foo.py' % prefix, 'bar.hoge.foo')
-    iglob.assert_called_once_with(
-        os.path.normpath('/a/%s/**/*.py' % prefix),
-        recursive=True,
+    assert next(it) == ('/a/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
+    walk.assert_called_once_with(
+        os.path.normpath('/a/%s' % prefix),
     )
-    iglob.reset_mock()
+    walk.reset_mock()
 
     assert next(it) == ('/b/%s/foo.py' % prefix, 'foo')
     assert next(it) == ('/b/%s/bar/__init__.py' % prefix, 'bar')
-    assert next(it) == ('/b/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/b/%s/bar/foo.py' % prefix, 'bar.foo')
+    assert next(it) == ('/b/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/b/%s/bar/hoge/__init__.py' % prefix, 'bar.hoge')
-    assert next(it) == ('/b/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
     assert next(it) == ('/b/%s/bar/hoge/foo.py' % prefix, 'bar.hoge.foo')
-    iglob.assert_called_once_with(
-        os.path.normpath('/b/%s/**/*.py' % prefix),
-        recursive=True,
+    assert next(it) == ('/b/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
+    walk.assert_called_once_with(
+        os.path.normpath('/b/%s' % prefix),
     )
-    iglob.reset_mock()
+    walk.reset_mock()
 
     with pytest.raises(StopIteration):
         next(it)
-    iglob.assert_not_called()
+    walk.assert_not_called()
 
-@patch('denite.util.iglob')
-def test_find_rplugins_filter(iglob):
-    iglob.side_effect = _iglob_side_effect
+
+@patch('denite.util.os.walk')
+def test_find_rplugins_filter(walk):
+    walk.side_effect = _walk_side_effect
 
     context = { 'runtimepath': '/a,/b' }
     source = 'filter'
@@ -124,42 +123,40 @@ def test_find_rplugins_filter(iglob):
     )]
 
     it = util.find_rplugins(context, source, loaded_paths)
-    iglob.assert_not_called()
+    walk.assert_not_called()
 
     assert next(it) == ('/a/%s/foo.py' % prefix, 'foo')
     assert next(it) == ('/a/%s/bar/__init__.py' % prefix, 'bar')
-    assert next(it) == ('/a/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/a/%s/bar/foo.py' % prefix, 'bar.foo')
+    assert next(it) == ('/a/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/a/%s/bar/hoge/__init__.py' % prefix, 'bar.hoge')
-    assert next(it) == ('/a/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
     assert next(it) == ('/a/%s/bar/hoge/foo.py' % prefix, 'bar.hoge.foo')
-    iglob.assert_called_once_with(
-        os.path.normpath('/a/%s/**/*.py' % prefix),
-        recursive=True,
+    assert next(it) == ('/a/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
+    walk.assert_called_once_with(
+        os.path.normpath('/a/%s' % prefix),
     )
-    iglob.reset_mock()
+    walk.reset_mock()
 
     assert next(it) == ('/b/%s/foo.py' % prefix, 'foo')
     assert next(it) == ('/b/%s/bar/__init__.py' % prefix, 'bar')
-    assert next(it) == ('/b/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/b/%s/bar/foo.py' % prefix, 'bar.foo')
+    assert next(it) == ('/b/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/b/%s/bar/hoge/__init__.py' % prefix, 'bar.hoge')
-    assert next(it) == ('/b/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
     assert next(it) == ('/b/%s/bar/hoge/foo.py' % prefix, 'bar.hoge.foo')
-    iglob.assert_called_once_with(
-        os.path.normpath('/b/%s/**/*.py' % prefix),
-        recursive=True,
+    assert next(it) == ('/b/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
+    walk.assert_called_once_with(
+        os.path.normpath('/b/%s' % prefix),
     )
-    iglob.reset_mock()
+    walk.reset_mock()
 
     with pytest.raises(StopIteration):
         next(it)
-    iglob.assert_not_called()
+    walk.assert_not_called()
 
 
-@patch('denite.util.iglob')
-def test_find_rplugins_kind(iglob):
-    iglob.side_effect = _iglob_side_effect
+@patch('denite.util.os.walk')
+def test_find_rplugins_kind(walk):
+    walk.side_effect = _walk_side_effect
 
     context = { 'runtimepath': '/a,/b' }
     source = 'kind'
@@ -170,58 +167,52 @@ def test_find_rplugins_kind(iglob):
     )]
 
     it = util.find_rplugins(context, source, loaded_paths)
-    iglob.assert_not_called()
+    walk.assert_not_called()
 
-    assert next(it) == ('/a/%s/base.py' % prefix, 'base')
     assert next(it) == ('/a/%s/foo.py' % prefix, 'foo')
+    assert next(it) == ('/a/%s/base.py' % prefix, 'base')
     assert next(it) == ('/a/%s/bar/__init__.py' % prefix, 'bar')
-    assert next(it) == ('/a/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/a/%s/bar/foo.py' % prefix, 'bar.foo')
+    assert next(it) == ('/a/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/a/%s/bar/hoge/__init__.py' % prefix, 'bar.hoge')
-    assert next(it) == ('/a/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
     assert next(it) == ('/a/%s/bar/hoge/foo.py' % prefix, 'bar.hoge.foo')
-    iglob.assert_called_once_with(
-        os.path.normpath('/a/%s/**/*.py' % prefix),
-        recursive=True,
+    assert next(it) == ('/a/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
+    walk.assert_called_once_with(
+        os.path.normpath('/a/%s' % prefix),
     )
-    iglob.reset_mock()
+    walk.reset_mock()
 
-    assert next(it) == ('/b/%s/base.py' % prefix, 'base')
     assert next(it) == ('/b/%s/foo.py' % prefix, 'foo')
+    assert next(it) == ('/b/%s/base.py' % prefix, 'base')
     assert next(it) == ('/b/%s/bar/__init__.py' % prefix, 'bar')
-    assert next(it) == ('/b/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/b/%s/bar/foo.py' % prefix, 'bar.foo')
+    assert next(it) == ('/b/%s/bar/base.py' % prefix, 'bar.base')
     assert next(it) == ('/b/%s/bar/hoge/__init__.py' % prefix, 'bar.hoge')
-    assert next(it) == ('/b/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
     assert next(it) == ('/b/%s/bar/hoge/foo.py' % prefix, 'bar.hoge.foo')
-    iglob.assert_called_once_with(
-        os.path.normpath('/b/%s/**/*.py' % prefix),
-        recursive=True,
+    assert next(it) == ('/b/%s/bar/hoge/base.py' % prefix, 'bar.hoge.base')
+    walk.assert_called_once_with(
+        os.path.normpath('/b/%s' % prefix),
     )
-    iglob.reset_mock()
+    walk.reset_mock()
 
     with pytest.raises(StopIteration):
         next(it)
-    iglob.assert_not_called()
+    walk.assert_not_called()
 
 
-def _iglob_side_effect(pathname, *, recursive=False):
-    root = pathname.replace(os.path.join('**', '*.py'), '')
-    candidates = (
-        '__init__.py',
-        'base.py',
-        'foo.py',
-        'loaded.py',
-        'bar/__init__.py',
-        'bar/base.py',
-        'bar/foo.py',
-        'bar/loaded.py',
-        'bar/hoge/__init__.py',
-        'bar/hoge/base.py',
-        'bar/hoge/foo.py',
-        'bar/hoge/loaded.py',
+def _walk_side_effect(top, topdown=True, onerror=None, followlinks=False):
+    yield (
+        top,
+        ['bar'],
+        ['__init__.py', 'foo.py', 'base.py', 'loaded.py'],
     )
-    return (
-        os.path.normpath(os.path.join(root, x))
-        for x in candidates
+    yield (
+        os.path.join(top, 'bar'),
+        ['hoge'],
+        ['__init__.py', 'foo.py', 'base.py', 'loaded.py'],
+    )
+    yield (
+        os.path.join(top, 'bar', 'hoge'),
+        ['hoge'],
+        ['__init__.py', 'foo.py', 'base.py', 'loaded.py'],
     )


### PR DESCRIPTION
'recursive' keyword is supported from Python 3.5 so use os.walk instead.

It close #456