### PR TITLE
Disable modeline for denite buffer

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -188,6 +188,7 @@ class Default(object):
         self._options['buftype'] = 'nofile'
         self._options['swapfile'] = False
         self._options['buflisted'] = False
+        self._options['modeline'] = False
         self._options['filetype'] = 'denite'
 
         self._window_options = self._vim.current.window.options


### PR DESCRIPTION
The line that starts with `vim:` could be considered as vim mode line which would throw an error when exit denite buffer:

```
[denite] Traceback (most recent call last):
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/default.py", line 71, in start
[denite]     self._start(context['sources_queue'][0], context)
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/default.py", line 136, in _start
[denite]     status = self._prompt.start()
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/prompt/prompt.py", line 201, in start
[denite]     raise e
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/prompt/prompt.py", line 191, in start
[denite]     interval=self.harvest_interval,
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/prompt.py", line 96, in on_keypress
[denite]     ret = self.action.call(self, m.group('action'))
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/prompt/action.py", line 139, in call
[denite]     return fn(prompt, params)
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/action.py", line 14, in _quit
[denite]     return prompt.denite.quit()
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/default.py", line 640, in quit
[denite]     self.quit_buffer()
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/default.py", line 589, in quit_buffer
[denite]     self.cleanup()
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/default.py", line 582, in cleanup
[denite]     self._vim.command('silent doautocmd ColorScheme')
[denite]   File "/usr/local/lib/python3.6/site-packages/neovim/api/nvim.py", line 242, in command
[denite]     return self.request('nvim_command', string, **kwargs)
[denite]   File "/usr/local/lib/python3.6/site-packages/neovim/api/nvim.py", line 140, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/usr/local/lib/python3.6/site-packages/neovim/msgpack_rpc/session.py", line 98, in request
[denite]     raise self.error_wrapper(err)
[denite] neovim.api.nvim.NvimError: b'Vim(doautocmd):E518: Unknown option: test '
[denite]
[denite] During handling of the above exception, another exception occurred:
[denite]
[denite] Traceback (most recent call last):
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/__init__.py", line 29, in start
[denite]     return ui.start(args[0], args[1])
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/default.py", line 75, in start
[denite]     self.cleanup()
[denite]   File "/Users/chemzqm/.vim/bundle/denite.nvim/rplugin/python3/denite/ui/default.py", line 582, in cleanup
[denite]     self._vim.command('silent doautocmd ColorScheme')
[denite]   File "/usr/local/lib/python3.6/site-packages/neovim/api/nvim.py", line 242, in command
[denite]     return self.request('nvim_command', string, **kwargs)
[denite]   File "/usr/local/lib/python3.6/site-packages/neovim/api/nvim.py", line 140, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/usr/local/lib/python3.6/site-packages/neovim/msgpack_rpc/session.py", line 98, in request
[denite]     raise self.error_wrapper(err)
[denite] neovim.api.nvim.NvimError: b'Vim(doautocmd):E518: Unknown option: test '
[denite] Please execute :messages command.
```
Solution: disable modeline option for denite buffer.