### PR TITLE
Fix ProcessLookupError when opening a file in a large tree

### DIFF
--- a/rplugin/python3/denite/process.py
+++ b/rplugin/python3/denite/process.py
@@ -35,8 +35,12 @@ class Process(object):
     def kill(self):
         if not self._proc:
             return
-        self._proc.kill()
-        self._proc.wait()
+
+        if self._proc.poll() is None:
+            # _proc is running
+            self._proc.kill()
+            self._proc.wait()
+
         self._proc = None
         self._queue_out = None
         self._thread.join(1.0)


### PR DESCRIPTION
### Problem:
I often get a ProcessLookupError when opening a file in a large tree.
The mapped command is `Denite -auto-resize -highlight-mode-insert=Search file_rec buffer<CR>`
This is the traceback shown in my vim8

```
-- INSERT --  file_rec(1000/74004) buffer [async]
[denite] Traceback (most recent call last):
[denite]   File "<string>", line 9, in _temporary_scope
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/ui/default.py", line 71, in start
[denite]     self._start(context['sources_queue'][0], context)
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/ui/default.py", line 136, in _start
[denite]     status = self._prompt.start()
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/prompt/prompt.py", line 191, in start
[denite]     interval=self.harvest_interval,
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/ui/prompt.py", line 96, in on_keypress
[denite]     ret = self.action.call(self, m.group('action'))
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/prompt/action.py", line 139, in call
[denite]     return fn(prompt, params)
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/ui/action.py", line 18, in _do_action
[denite]     return prompt.denite.do_action(params)
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/ui/default.py", line 694, in do_action
[denite]     self.quit()
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/ui/default.py", line 647, in quit
[denite]     self._denite.on_close(self._context)
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/denite.py", line 214, in on_close
[denite]     source.on_close(source.context)
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/source/file/rec.py", line 52, in on_close
[denite]     context['__proc'].kill()
[denite]   File "/Users/weitang114/.vim/plugged/denite.nvim/rplugin/python3/denite/process.py", line 38, in kill
[denite]     self._proc.kill()
[denite]   File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 1590, in kill
[denite]     self.send_signal(signal.SIGKILL)
[denite]   File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 1580, in send_signal
[denite]     os.kill(self.pid, sig)
[denite] ProcessLookupError: [Errno 3] No such process
[denite] Please execute :messages command.
Press ENTER or type command to continue
```

### Fix:
Only kill the subprocess if the process is still running.

### Environment: 
 - MacOS 10.12.6
 - vim8
 - python3.6
 - latest denite.nvim