### PR TITLE
Fixes to line source and parse tagline

### DIFF
--- a/rplugin/python3/denite/source/line.py
+++ b/rplugin/python3/denite/source/line.py
@@ -59,6 +59,7 @@ class Source(Base):
                 'word': x,
                 'abbr': (context['__fmt'] % (i + 1, x)),
                 'action__path': self.vim.call('bufname', bufnr),
+                'action__col': 0,
                 'action__line': (i + 1),
                 'action__text': x,
             } for [i, x] in enumerate(

--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 from glob import glob
-from os.path import normpath, normcase, join, dirname
+from os.path import normpath, normcase, join, dirname, exists
 from importlib.machinery import SourceFileLoader
 
 
@@ -248,9 +248,10 @@ def import_rplugins(name, context, source, loaded_paths):
 
 def parse_tagline(line, tagpath):
     elem = line.split("\t")
+    file_path = elem[1] if exists(elem[1]) else normpath(join(dirname(tagpath), elem[1]))
     info = {
         'name': elem[0],
-        'file': normpath(join(dirname(tagpath), elem[1])),
+        'file': file_path,
         'pattern': '',
         'line': '',
         'type': '',


### PR DESCRIPTION
When using a quickfix action from the lines source, the quickfix action would throw an KeyError with `action__col`.

The logic of parse_tagline assumed that the tag file contains relative paths, not full paths. It now checks for existance before prepending tagpath.