### PR TITLE
Fix the broken :DeniteCursorWord

### DIFF
--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -210,6 +210,8 @@ class Source(Base):
             elif not isinstance(arg, list):
                 raise AttributeError(
                     '`args[2]` needs to be a `str` or `list`')
+        elif context['input']:
+            patterns = [context['input']]
         else:
             patterns = [util.input(self.vim, context,
                                    'Pattern: ', context['input'])]


### PR DESCRIPTION
In the grep optimisation checkin this snippet has been missed, due to that
DeniteCursorWord is expecting me to press enter before search which is
annoying :P