### PR TITLE
Added support to auto close the preview window based on user option

### DIFF
--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -114,6 +114,7 @@ function! denite#init#_user_options() abort
         \ 'auto_preview': v:false,
         \ 'auto_resize': v:false,
         \ 'auto_resume': v:false,
+        \ 'autoclose_preview': v:true,
         \ 'buffer_name': 'default',
         \ 'cursor_pos': '',
         \ 'cursor_wrap': v:false,

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1090,6 +1090,11 @@ OPTIONS							*denite-options*
 		Auto resume when enter the Denite window.
 		Default: false
 
+						*denite-option-autoclose-preview*
+-autoclose-preview
+		Auto close the preview window when quit the Denite window.
+		Default: true
+
 						*denite-option-buffer-name*
 -buffer-name={buffer-name}
 		Specify the name of denite buffer.

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -655,6 +655,8 @@ class Default(object):
         self._context['is_redraw'] = False
 
     def quit(self):
+        if self._context['autoclose_preview']:
+            self._vim.command('silent pclose!')
         self._denite.on_close(self._context)
         self.quit_buffer()
         self._result = []


### PR DESCRIPTION
When we use the auto-preview and quit the denite buffer by opening the file or pressing Ctrl-C, the preview window stays and does not close immediately.

Added an option autoclose-preview which will decide to close the preview window or not based on the option set.
