### PR TITLE
Fix python syntax error

### DIFF
--- a/rplugin/python3/denite/source/directory_rec.py
+++ b/rplugin/python3/denite/source/directory_rec.py
@@ -25,7 +25,7 @@ class Source(Rec):
 
         super().on_init(context)
 
-        if context['is_windows']
+        if context['is_windows']:
             self.vars['command'] = []
             self.error_message(context,
                                'Windows environment is not supported.')


### PR DESCRIPTION
Fix this syntax error that rerated with [this commit](https://github.com/Shougo/denite.nvim/commit/286b811782ddfb6c11cf2f7a5eada3a0f9a934cb#diff-9d383283541386143379af00565ba710R28).
```
[denite] Traceback (most recent call last):
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/__init__.py", line 29, in start
[denite]     return ui.start(args[0], args[1])
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 71, in start
[denite]     self._start(context['sources_queue'][0], context)
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 119, in _start
[denite]     self.init_denite()
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 672, in init_denite
[denite]     self._denite.start(self._context)
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/denite.py", line 38, in start
[denite]     self.load_sources(context)
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/denite.py", line 232, in load_sources
[denite]     for Source, path, _ in rplugins:
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/util.py", line 243, in import_rplugins
[denite]     module = loader.load_module()
[denite]   File "<frozen importlib._bootstrap_external>", line 407, in _check_name_wrapper
[denite]   File "<frozen importlib._bootstrap_external>", line 907, in load_module
[denite]   File "<frozen importlib._bootstrap_external>", line 732, in load_module
[denite]   File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
[denite]   File "<frozen importlib._bootstrap>", line 696, in _load
[denite]   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
[denite]   File "<frozen importlib._bootstrap_external>", line 724, in exec_module
[denite]   File "<frozen importlib._bootstrap_external>", line 860, in get_code
[denite]   File "<frozen importlib._bootstrap_external>", line 791, in source_to_code
[denite]   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/source/directory_rec.py", line 28
[denite]     if context['is_windows']
[denite]                            ^
[denite] SyntaxError: invalid syntax
[denite] Please execute :messages command.
Press ENTER or type command to continue
```