### PR TITLE
revert execute command of execute_path()

### DIFF
--- a/autoload/denite/util.vim
+++ b/autoload/denite/util.vim
@@ -35,7 +35,7 @@ function! denite#util#execute_path(command, path) abort
   endif
 
   try
-    execute a:command s:expand(a:path)
+    execute a:command '`=s:expand(a:path)`'
   catch /^Vim\%((\a\+)\)\=:E325/
     " Ignore swap file error
   catch


### PR DESCRIPTION
An error appeared in a907dc01 when executing Denite.

NVIM 0.3.2-861-g9f3fb5511 on Windows 10
Python 3.7.1, neovim-python 0.3.0
