### PR TITLE
Fix the `:Denite tag`'s edit action for vimhelp's tags

### DIFF
--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -150,6 +150,11 @@ class Kind(Openable):
     def _jump(self, context, target):
         if 'action__pattern' in target:
             self.vim.call('search', target['action__pattern'], 'w')
+        if 'action__line' in target and type(target['action__line']) is str:
+            pattern = target['action__line'].replace('*', '\*')
+            self.vim.call('search', pattern, 'n')
+            self.vim.call('execute', 'normal! ggn')
+            target['action__line'] = 0
 
         line = int(target.get('action__line', 0))
         col = int(target.get('action__col', 0))


### PR DESCRIPTION
Hi :smile:

I have an issue of the title.
This PR fixes it :dog2:

For reproduce

1. `:h denite`
1. `:Denite tag`
1. Input 'denite' at the denite buffer
1. Enter
1. :point_down:

```
[denite] Traceback (most recent call last):
[denite]   File "<string>", line 9, in _temporary_scope
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/ui/default.py", line 70, in start
[denite]     self._start(context['sources_queue'][0], context)
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/ui/default.py", line 137, in _start
[denite]     status = self._prompt.start()
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/prompt/prompt.py", line 191, in start
[denite]     interval=self.harvest_interval,
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/ui/prompt.py", line 96, in on_keypress
[denite]     ret = self.action.call(self, m.group('action'))
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/prompt/action.py", line 139, in call
[denite]     return fn(prompt, params)
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/ui/action.py", line 18, in _do_action
[denite]     return prompt.denite.do_action(params)
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/ui/default.py", line 671, in do_action
[denite]     self._denite.do_action(self._context, action_name, candidates)
[denite]   File "/home/aiya000/.dotfiles/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/denite.py", line 243, in do_action
[denite]     return action['func'](context) if action['func'] else self._vim.call(
[denite]   File "/home/aiya000/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/kind/file.py", line 27, in action_open
[denite]     self._open(context, 'edit')
[denite]   File "/home/aiya000/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/kind/file.py", line 132, in _open
[denite]     self._jump(context, target)
[denite]   File "/home/aiya000/.vim/bundle/.cache/.vimrc/.dein/rplugin/python3/denite/kind/file.py", line 154, in _jump
[denite]     line = int(target.get('action__line', 0))
[denite] ValueError: invalid literal for int() with base 10: '/*denite*'
[denite] Please execute :messages command.)
```

This PR maybe dirty, because I couldn't fix this by the deeply way, sorry :joy:
Please abandon this if you can fix by yourself.

PS. My Vim is this :point_down:

```
VIM - Vi IMproved 8.1 (2018 May 18, compiled Dec 14 2018 22:21:17)
適用済パッチ: 1-582
Compiled by aiya000
Huge 版 with GTK2 GUI.  機能の一覧 有効(+)/無効(-)
+acl               +clientserver      +diff              +folding           +libcall           +mouse_gpm         +packages          +ruby              +termguicolors     +virtualedit       +xpm
+arabic            +clipboard         +digraphs          -footer            +linebreak         -mouse_jsbterm     +path_extra        +scrollbind        +terminal          +visual            +xsmp_interact
+autocmd           +cmdline_compl     +dnd               +fork()            +lispindent        +mouse_netterm     +perl              +signs             +terminfo          +visualextra       +xterm_clipboard
+autochdir         +cmdline_hist      -ebcdic            +gettext           +listcmds          +mouse_sgr         +persistent_undo   +smartindent       +termresponse      +viminfo           -xterm_save
-autoservername    +cmdline_info      +emacs_tags        -hangul_input      +localmap          -mouse_sysmouse    +postscript        +startuptime       +textobjects       +vreplace
+balloon_eval      +comments          +eval              +iconv             +lua/dyn           +mouse_urxvt       +printer           +statusline        +textprop          +wildignore
+balloon_eval_term +conceal           +ex_extra          +insert_expand     +menu              +mouse_xterm       +profile           -sun_workshop      +timers            +wildmenu
+browse            +cryptv            +extra_search      +job               +mksession         +multi_byte        +python/dyn        +syntax            +title             +windows
++builtin_terms    +cscope            +farsi             +jumplist          +modify_fname      +multi_lang        +python3/dyn       +tag_binary        +toolbar           +writebackup
+byte_offset       +cursorbind        +file_in_path      +keymap            +mouse             -mzscheme          +quickfix          +tag_old_static    +user_commands     +X11
+channel           +cursorshape       +find_in_path      +lambda            +mouseshape        +netbeans_intg     +reltime           -tag_any_white     +vartabs           -xfontset
+cindent           +dialog_con_gui    +float             +langmap           +mouse_dec         +num64             +rightleft         -tcl               +vertsplit         +xim
システム vimrc: "$VIM/vimrc"
ユーザー vimrc: "$HOME/.vimrc"
第2ユーザー vimrc: "~/.vim/vimrc"
ユーザー exrc: "$HOME/.exrc"
システム gvimrc: "$VIM/gvimrc"
ユーザー gvimrc: "$HOME/.gvimrc"
第2ユーザー gvimrc: "~/.vim/gvimrc"
デフォルトファイル: "$VIMRUNTIME/defaults.vim"
システムメニュー: "$VIMRUNTIME/menu.vim"
省略時の $VIM: "/usr/local/share/vim"
```