### PR TITLE
Add matcher that expands ~ and env vars

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1785,6 +1785,11 @@ matcher/cpsm (matcher_cpsm)
 		Note: You must use Python3 support enabled cpsm. >
 			$ PY3=ON ./install.sh
 <
+						*denite-filter-matcher/expand*
+matcher/expand
+		A matcher which filters the candidates using texts expanded
+		with any environment variable and the ~ char (`$HOME`).
+
 						*denite-filter-matcher/fuzzy*
 						*denite-filter-matcher_fuzzy*
 matcher/fuzzy (matcher_fuzzy)

--- a/rplugin/python3/denite/filter/matcher/expand.py
+++ b/rplugin/python3/denite/filter/matcher/expand.py
@@ -1,0 +1,36 @@
+# ============================================================================
+# FILE: matcher/expand.py
+# AUTHOR: JINNOUCHI Yasushi <delphinus@remora.cx>
+# License: MIT license
+# ============================================================================
+
+import re
+
+from denite.filter.base import Base
+from denite.util import expand, split_input
+
+
+class Filter(Base):
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'matcher/expand'
+        self.description = 'expand `~` char & any env variable'
+
+    def filter(self, context):
+        candidates = context['candidates']
+        ignorecase = context['ignorecase']
+        pattern = context['input']
+        if pattern == '':
+            return candidates
+
+        expanded = expand(pattern)
+        if ignorecase:
+            candidates = [x for x in candidates
+                          if expanded.lower() in x['word'].lower()]
+        else:
+            candidates = [x for x in candidates if expanded in x['word']]
+        return candidates
+
+    def convert_pattern(self, input_str):
+        return '|'.join([re.escape(expand(x)) for x in split_input(input_str)])


### PR DESCRIPTION
When I'm using `file` / `file/old` sources, I often want to narrow candidates to find files under the typical directories such as `~` (`$HOME`), `$VIM`, `$GOPATH`, and so on.  It can be done with this matcher.  This expands `input_str` with `denite.util.expand()`, and converts as such below.

```
~/git/repo
  → /Users/username/git/repo
$VIMRUNTIME/syntax/python.vim
  → /usr/local/Cellar/neovim/0.3.3/share/nvim/runtime/syntax/python.vim
```