### PR TITLE
add action__path to line source candidate

### DIFF
--- a/rplugin/python3/denite/source/line.py
+++ b/rplugin/python3/denite/source/line.py
@@ -58,6 +58,7 @@ class Source(Base):
             lines = [{
                 'word': x,
                 'abbr': (context['__fmt'] % (i + 1, x)),
+                'action__path': self.vim.current.buffer.name,
                 'action__bufnr': bufnr,
                 'action__col': 0,
                 'action__line': (i + 1),


### PR DESCRIPTION
The kind of line source is `file`. It's require `action__path`.
I want this parameter for `quickfix` action.