### PR TITLE
fix method name

### DIFF
--- a/rplugin/python3/denite/ui/prompt.py
+++ b/rplugin/python3/denite/ui/prompt.py
@@ -56,7 +56,7 @@ class DenitePrompt(Prompt):
         return status
 
     def on_update(self, status):
-        if self.denite.is_async and self.denite.check_empty():
+        if self.denite.is_async and self.denite.check_option():
             self.denite.quit()
             return STATUS_CANCEL
         return super().on_update(status)


### PR DESCRIPTION
`check_empty` method was renamed to 'check_option' in bd20645b11be38cdea42ef562d18f48d78be850d
but old method name was remaind, I fixed it.
