### PR TITLE
Fix python executable for scantree

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -200,16 +200,17 @@ function! denite#helper#_set_available_sources(source_names) abort
   let s:source_names = a:source_names
 endfunction
 function! s:_get_source_name(path) abort
-  if a:path ==# '__init__.py' || a:path ==# 'base.py'
+  let path_f = fnamemodify(a:path, ':gs?\\?/?')
+  if path_f ==# '__init__.py' || path_f ==# 'base.py'
     return ''
-  elseif a:path[-12:] ==# '/__init__.py'
-    if getfsize(a:path) == 0
+  elseif path_f[-12:] ==# '/__init__.py'
+    if getfsize(path_f) == 0
       " Probably the file exists for making a namespace so ignore
       return ''
     endif
-    return fnamemodify(a:path, ':h:s?.*/rplugin/python3/denite/source/??:r')
+    return fnamemodify(path_f, ':h:s?.*/rplugin/python3/denite/source/??:r')
   endif
-  return fnamemodify(a:path, ':s?.*/rplugin/python3/denite/source/??:r')
+  return fnamemodify(path_f, ':s?.*/rplugin/python3/denite/source/??:r')
 endfunction
 
 function! denite#helper#_get_wininfo() abort

--- a/rplugin/python3/denite/source/file/rec.py
+++ b/rplugin/python3/denite/source/file/rec.py
@@ -8,7 +8,7 @@ import argparse
 import shutil
 from sys import executable, base_exec_prefix
 from os import path, pardir
-from os.path import relpath, isabs, isdir, join, normpath, basename
+from os.path import relpath, isabs, isdir, join, normpath, basename, exists
 
 from denite.base.source import Base
 from denite.process import Process
@@ -125,7 +125,7 @@ class Source(Base):
                 return shutil.which(exe)
 
         for name in (join(base_exec_prefix, v) for v in ['python3', 'python',
-                join('bin', 'python3'), join('bin', 'python')]):
+                     join('bin', 'python3'), join('bin', 'python')]):
             if exists(name):
                 return name
 

--- a/rplugin/python3/denite/source/file/rec.py
+++ b/rplugin/python3/denite/source/file/rec.py
@@ -6,9 +6,9 @@
 
 import argparse
 import shutil
-from sys import executable
+from sys import executable, base_exec_prefix
 from os import path, pardir
-from os.path import relpath, isabs, isdir, join, normpath
+from os.path import relpath, isabs, isdir, join, normpath, basename
 
 from denite.base.source import Base
 from denite.process import Process
@@ -115,6 +115,23 @@ class Source(Base):
 
         return candidates
 
+    @staticmethod
+    def get_python_exe():
+        if 'py' in basename(executable):
+            return executable
+
+        for exe in ['python3', 'python']:
+            if shutil.which(exe) is not None:
+                return shutil.which(exe)
+
+        for name in (join(base_exec_prefix, v) for v in ['python3', 'python',
+                join('bin', 'python3'), join('bin', 'python')]):
+            if exists(name):
+                return name
+
+        # return sys.executable anyway. This may not work on windows
+        return executable
+
     def parse_command_for_scantree(self, cmd):
         """Given the user choice for --ignore get the corresponding value"""
 
@@ -133,5 +150,5 @@ class Source(Base):
         scantree_py = normpath(join(current_folder,
                                     pardir, pardir, 'scantree.py'))
 
-        return [executable, scantree_py, '--ignore', ignore,
+        return [Source.get_python_exe(), scantree_py, '--ignore', ignore,
                 '--path', ':directory']


### PR DESCRIPTION
In windows we cannot use sys.executable all the time.
In my case sys.executable is pointing to vim executable not for python executable.
So we need a more robust way of getting the python executable name.

It should be possible to directly use the function using python but I don't know how to get the result in that case.

The other fix is because the completion logic doesn't work in windows because the path separator is '\' instead of '/'.
I convert this before and then it works.

Please change what you find necessary to change.