### PR TITLE
Fix mark source for lowercase marks

### DIFF
--- a/rplugin/python3/denite/source/mark.py
+++ b/rplugin/python3/denite/source/mark.py
@@ -53,7 +53,7 @@ class Source(Base):
             if self.empty_mark(mark_info):
                 continue
 
-            bufname = self.vim.call('bufname', bufnum)
+            bufname = self.vim.call('bufname', bufnum if bufnum != 0 else "%")
             path = self.vim.call('fnamemodify', bufname, ':p')
             if bufnum == 0:
                 file_or_text = 'text: ' + self.vim.call('getline', lnum)


### PR DESCRIPTION
In the old implementation, `bufname()` used the `bufnum` returned from `getpos()`, which will be `0` if it's a lowercase mark. Thus, `bufname()` is empty in this case, which is not desired to call with `fnamemodify()`.

This PR fixes this issue by replacing `bufnum` with `"%"` if `bufnum` is `0` when calling `bufname()`.