### PR TITLE
Vim: Fix hang when feed Ctrl-C on prompt

### DIFF
--- a/autoload/denite/util.vim
+++ b/autoload/denite/util.vim
@@ -63,6 +63,16 @@ function! denite#util#echo(color, string) abort
   echohl NONE
 endfunction
 
+function! denite#util#getchar(...) abort
+  try
+    return call('getchar', a:000)
+  catch /^Vim:Interrupt/
+    return 3
+  catch
+    return 0
+  endtry
+endfunction
+
 function! denite#util#open(filename) abort
   let filename = fnamemodify(a:filename, ':p')
 

--- a/rplugin/python3/denite/base/kind.py
+++ b/rplugin/python3/denite/base/kind.py
@@ -23,7 +23,7 @@ class Base(object):
         self.vim.command('redraw')
         for target in context['targets']:
             self.debug(target)
-        self.vim.call('getchar')
+        self.vim.call('denite#util#getchar')
 
     def action_yank(self, context):
         _yank(self.vim, "\n".join([

--- a/rplugin/python3/denite/child.py
+++ b/rplugin/python3/denite/child.py
@@ -253,7 +253,7 @@ class Child(object):
 
     def error(self, msg):
         self._vim.call('denite#util#print_error', msg)
-        self._vim.call('getchar')
+        self._vim.call('denite#util#getchar')
 
     def _filter_candidates(self, context):
         for source in self._current_sources:

--- a/rplugin/python3/denite/kind/command.py
+++ b/rplugin/python3/denite/kind/command.py
@@ -43,4 +43,4 @@ class Kind(Base):
             return
         self.vim.command('redraw')
         self.debug(output)
-        self.vim.call('getchar')
+        self.vim.call('denite#util#getchar')

--- a/rplugin/python3/denite/prompt/util.py
+++ b/rplugin/python3/denite/prompt/util.py
@@ -147,7 +147,7 @@ def getchar(nvim, *args):
         Union[int, bytes]: A int or bytes.
     """
     try:
-        ret = nvim.call('getchar', *args)
+        ret = nvim.call('denite#util#getchar', *args)
         if isinstance(ret, int):
             if ret == 0x03:
                 # NOTE

--- a/rplugin/python3/denite/ui/action.py
+++ b/rplugin/python3/denite/ui/action.py
@@ -233,7 +233,7 @@ def _change_sorters(prompt, params):
 def _print_messages(prompt, params):
     for mes in prompt.denite._context['messages']:
         debug(prompt.nvim, mes)
-    prompt.nvim.call('getchar')
+    prompt.nvim.call('denite#util#getchar')
 
 
 def _change_path(prompt, params):

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -983,7 +983,8 @@ class Default(object):
 
         char = ''
         while char == '':
-            char = self._vim.call('nr2char', self._vim.call('getchar'))
+            char = self._vim.call('nr2char',
+                                  self._vim.call('denite#util#getchar'))
 
         quick_move_redraw(quick_move_table, False)
 


### PR DESCRIPTION
## Problem

Vim hangs up when feeding Ctrl-C on denite prompt.

## Repro steps

Vim 8.1.1071

vimrc:
```vim
set rtp+=/path/to/denite.nvim
set rtp+=/path/to/nvim-yarp
set rtp+=/path/to/vim-hug-neovim-rpc
let g:python3_host_prog = exepath('python3')
```

```
$ vim -Nu vimrc
:Denite buffer<CR>
```

feed Ctrl-C, and then Vim will hang.

## Cause

```
denite#helper#call_denite()
 -> denite#start()
     -> denite#util#rpcrequest()
         -> g:denite#_yarp.request() (== yarp#core#request())
             -> neovim_rpc#rpcrequest()
                 -> ch_evalexpr()
                     -> pythonx neovim_rpc_server.process_pending_requests() (in vim-hug-neovim-rpc)
```

When feeding Ctrl-C, `KeyboardInterrupt` occurs and it breaks while-loop in `neovim_rpc_server.process_pending_requests()` so Vim cannot communicate with the peer (denite) and then waits a message until timeout (24h: set by vim-hug-neovim-rpc) expires.

by `ch_logfile('denite.log')`:
```
  (..snip..)
  4.285587 : looking for messages on channels
  4.285767 : ERROR: Traceback (most recent call last):
  4.285794 : ERROR:   File "<string>", line 1, in <module>
  4.286034 : ERROR:   File "/path/to/vim-hug-neovim-rpc/pythonx/neovim_rpc_server.py", line 396, in process_pending_requests
  4.286514 : ERROR:     result = _process_request(channel, method, args)
  4.286540 : ERROR:   File "/path/to/vim-hug-neovim-rpc/pythonx/neovim_rpc_server.py", line 431, in _process_request
  4.286817 : ERROR:     return getattr(neovim_rpc_methods, method)(*args)
  4.286842 : ERROR:   File "/path/to/vim-hug-neovim-rpc/pythonx/neovim_rpc_methods.py", line 11, in nvim_call_function
  4.286971 : ERROR:     return vim.bindeval('call("%s",g:_neovim_rpc_tmp_args)' % method)
  4.287004 : ERROR: KeyboardInterrupt
  4.287021 on 0: Ex command error: 'KeyboardInterrupt'
  4.287036 : looking for messages on channels
  4.287048 on 0: Waiting for up to 86400000 msec
```

## Solution proposal

* Wrap `getchar()` of Vim by `denite#util#getchar()` and make it handle interrupt exception

Should I separate the impl of `denite#util#getchar()` between Vim and Neovim (since Neovim doesn't need it) as the following?

```vim
if has('nvim')
  function! denite#util#getchar(...) abort
    return call('getchar', a:000)
  endfunction
else
  function! denite#util#getchar(...) abort
    try
      return call('getchar', a:000)
    catch /^Vim:Interrupt/
      return 3
    catch
      return 0
    endtry
  endfunction
endif
```
