### PR TITLE
Fix immediately option

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -579,7 +579,8 @@ class Default(object):
         # Clear previewed buffers
         if not self._is_suspend and not self._context['has_preview_window']:
             self._vim.command('pclose!')
-        for bufnr in self._vim.vars['denite#_previewed_buffers'].keys():
+        for bufnr in self._vim.vars.get(
+                'denite#_previewed_buffers', {}).keys():
             if not self._vim.call('win_findbuf', bufnr):
                 self._vim.command('silent bdelete ' + str(bufnr))
         self._vim.vars['denite#_previewed_buffers'] = {}


### PR DESCRIPTION
Right after neovim starts, `Denite file/rec -immediately` causes an error.
This pull-request fixed the error.

### minimal init.vim

```
set runtimepath+=~/.vim/minpac/pack/minpac/start/denite.nvim
```

### Full error text

```
[denite] Traceback (most recent call last):
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 81, in start
[denite]     self._start(context['sources_queue'][0], context)
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 144, in _start
[denite]     if self.check_option():
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 497, in check_option
[denite]     self.do_immediately()
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 509, in do_immediately
[denite]     self.do_action('default')
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 710, in do_action
[denite]     self.quit()
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 650, in quit
[denite]     self.quit_buffer()
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 601, in quit_buffer
[denite]     self.cleanup()
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 582, in cleanup
[denite]     for bufnr in self._vim.vars['denite#_previewed_buffers'].keys():
[denite]   File "/usr/lib/python3.6/site-packages/pynvim/api/common.py", line 88, in __getitem__
[denite]     return self._get(key)
[denite]   File "/usr/lib/python3.6/site-packages/pynvim/api/nvim.py", line 182, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/usr/lib/python3.6/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
[denite]     raise self.error_wrapper(err)
[denite] pynvim.api.nvim.NvimError: b'Key not found: denite#_previewed_buffers'
[denite] 
[denite] During handling of the above exception, another exception occurred:
[denite] 
[denite] Traceback (most recent call last):
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/rplugin.py", line 25, in start
[denite]     return ui.start(args[0], context)
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 92, in start
[denite]     self.cleanup()
[denite]   File "/home/vagrant/.vim/minpac/pack/minpac/start/denite.nvim/rplugin/python3/denite/ui/default.py", line 582, in cleanup
[denite]     for bufnr in self._vim.vars['denite#_previewed_buffers'].keys():
[denite]   File "/usr/lib/python3.6/site-packages/pynvim/api/common.py", line 88, in __getitem__
[denite]     return self._get(key)
[denite]   File "/usr/lib/python3.6/site-packages/pynvim/api/nvim.py", line 182, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/usr/lib/python3.6/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
[denite]     raise self.error_wrapper(err)
[denite] pynvim.api.nvim.NvimError: b'Key not found: denite#_previewed_buffers'
[denite] Please execute :messages command.
```
