### PR TITLE
When filtering the path in `v:oldfiles`, needs to be `expand()`.

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -173,7 +173,8 @@ function! denite#helper#_set_oldfiles(oldfiles) abort
   let v:oldfiles = a:oldfiles
 endfunction
 function! denite#helper#_get_oldfiles() abort
-  return filter(copy(v:oldfiles), 'filereadable(v:val) || buflisted(v:val)')
+  return filter(copy(v:oldfiles),
+        \ 'filereadable(expand(v:val)) || buflisted(expand(v:val))')
 endfunction
 
 


### PR DESCRIPTION
```vim
echo filereadable('~/exists.file') " => 0
echo filereadable(expand('~/exists.file')) " => 1
```