### PR TITLE
Feature: Jump cursor after switch action.

### DIFF
--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -149,6 +149,7 @@ class Kind(Openable):
                                 not x.options['previewwindow'],
                                 self.vim.windows), None)
 
+    # Needed for openable actions
     def _jump(self, context, target):
         if 'action__pattern' in target:
             self.vim.call('search', target['action__pattern'], 'w')

--- a/rplugin/python3/denite/kind/openable.py
+++ b/rplugin/python3/denite/kind/openable.py
@@ -80,6 +80,8 @@ class Kind(Base):
             winid = self._winid(target)
             if winid:
                 self.vim.call('win_gotoid', winid)
+                if callable(self._jump):
+                    self._jump(context, target)
             else:
                 fallback(context)
 


### PR DESCRIPTION
Cursor is moved after `open` action, if the target has line or col data.
Do the same for `switch` action.