### PR TITLE
source-file: Use current directory, if args[1] is empty.

### DIFF
--- a/rplugin/python3/denite/source/file/__init__.py
+++ b/rplugin/python3/denite/source/file/__init__.py
@@ -25,6 +25,7 @@ class Source(Base):
         candidates = []
         path = (context['args'][1] if len(context['args']) > 1
                 else context['path'])
+        path = abspath(self.vim, path)
         inp = expand(context['input'])
         filename = (inp if os.path.isabs(inp) else os.path.join(path, inp))
         if context['args'] and context['args'][0] == 'new':


### PR DESCRIPTION
In file source.

Before: `Denite file::` in path `/foo/bar/baz`
```
../../../file1
../../../file2
```

After:
```
file1
file2
```