### PR TITLE
Fix error when default action can not detected.

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -695,10 +695,10 @@ class Default(object):
             self._context, action_name, candidates)
         if not action:
             # Search the prefix.
-            prefix_actions = [x for x in
-                              self._denite.get_action_names(
-                                  self._context, candidates)
-                              if x.startswith(action_name)]
+            prefix_actions = [
+                x for x in self._denite.get_action_names(
+                    self._context, candidates)
+                if x.startswith(action_name) and x != action_name]
             if not prefix_actions:
                 return
             action_name = prefix_actions[0]


### PR DESCRIPTION
If default-action is defined and it is not exists, error occurred in python.

e.g.: Default action set to `switch` and <kbd>Enter</kbd> on `directory` kind.
```
[denite] Invalid action: switch
[denite] Invalid action: switch
[denite] Traceback (most recent call last):
[denite]   File ".../denite.nvim/rplugin/python3/denite/rplugin.py", line 25, in start
[denite]     return ui.start(args[0], context)
[denite]   File ".../denite.nvim/rplugin/python3/denite/ui/default.py", line 81, in start
[denite]     self._start(context['sources_queue'][0], context)
[denite]   File ".../denite.nvim/rplugin/python3/denite/ui/default.py", line 159, in _start
[denite]     status = self._prompt.start()
[denite]   File ".../denite.nvim/rplugin/python3/denite/prompt/prompt.py", line 191, in start
[denite]     interval=self.harvest_interval,
[denite]   File ".../denite.nvim/rplugin/python3/denite/ui/prompt.py", line 96, in on_keypress
[denite]     ret = self.action.call(self, m.group('action'))
[denite]   File ".../denite.nvim/rplugin/python3/denite/prompt/action.py", line 139, in call
[denite]     return fn(prompt, params)
[denite]   File ".../denite.nvim/rplugin/python3/denite/ui/action.py", line 26, in _choose_action
[denite]     return prompt.denite.choose_action()
[denite]   File ".../denite.nvim/rplugin/python3/denite/ui/default.py", line 752, in choose_action
[denite]     return self.do_action(action)
[denite]   File ".../denite.nvim/rplugin/python3/denite/ui/default.py", line 710, in do_action
[denite]     is_quit = action['is_quit'] or post_action == 'quit'
[denite] KeyError: 'is_quit'
```