### PR TITLE
Always normalize file path when parse tagline

### DIFF
--- a/rplugin/python3/denite/util.py
+++ b/rplugin/python3/denite/util.py
@@ -271,7 +271,8 @@ def parse_tagline(line, tagpath):
     elem = line.split("\t")
     file_path = elem[1]
     if not exists(file_path):
-        file_path = normpath(join(dirname(tagpath), elem[1]))
+        file_path = join(dirname(tagpath), elem[1])
+    file_path = normpath(file_path)
     info = {
         'name': elem[0],
         'file': file_path,


### PR DESCRIPTION
On Windows, some ctags may return double-backslashed file paths. With those paths, denite opens double-slashed path, which vim treats as different file from original (single-backslashed) file. Avoid this by always normalizing file paths.