### PR TITLE
Fix file/old not listing paths under `~`

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -174,7 +174,7 @@ function! denite#helper#_set_oldfiles(oldfiles) abort
 endfunction
 function! denite#helper#_get_oldfiles() abort
   return filter(copy(v:oldfiles),
-        \ 'filereadable(v:val) || buflisted(v:val)')
+        \ 'filereadable(fnamemodify(v:val, ":p")) || buflisted(v:val)')
 endfunction
 
 


### PR DESCRIPTION
Commit 6915d94095cb236339e073c5467bf29f59732eaa had once fixed this problem, but f16b581357a575f37f4c51f6c809e8f2fd98b5bf has reverted that.
`fnamemodify()` seems to work for each case, but you may want to filter on python-side instead.