### PR TITLE
Improve command_history speed with lua

### DIFF
--- a/rplugin/python3/denite/source/command_history.py
+++ b/rplugin/python3/denite/source/command_history.py
@@ -21,6 +21,18 @@ class Source(Base):
         self.vars = {
             'ignore_command_regexp': []
         }
+        self.vim.exec_lua(
+            """
+            local function getHistory()
+                local histories = {}
+                local number = vim.api.nvim_call_function('histnr', {':'})
+                for i=1, number do
+                    histories[i] = {tostring(i), vim.api.nvim_call_function('histget', {':', i})}
+                end
+                return histories
+            end
+            history_source = {get=getHistory}
+            """)
 
     def gather_candidates(self, context):
         histories = self._get_histories()
@@ -32,10 +44,8 @@ class Source(Base):
                 if len(r) > 1 and r[1]]
 
     def _get_histories(self):
-        histories = [
-            [str(x), self.vim.call('histget', ':', x)]
-            for x in reversed(range(1, self.vim.call('histnr', ':')+1))
-        ]
+        histories = self.vim.lua.history_source.get()
+        histories.reverse()
         histories = self._remove_duplicate_entry(histories)
         if self.vars['ignore_command_regexp']:
             histories = list(filter(


### PR DESCRIPTION
Hi Shougo,

I find the command_history source is too slow in my usage due to large number of histories.
The bottleneck should be lots of nvim api calls from Python client.

With my code, the speed has been improved a lot. Would you please take a review ?

Thanks