### PR TITLE
Do not set hidden on opening filter buffer

### DIFF
--- a/autoload/denite/filter.vim
+++ b/autoload/denite/filter.vim
@@ -52,7 +52,6 @@ function! s:init_buffer() abort
   setlocal buftype=nofile
   setlocal colorcolumn=
   setlocal foldcolumn=0
-  setlocal hidden
   setlocal nobuflisted
   setlocal nofoldenable
   setlocal nolist


### PR DESCRIPTION
`'hidden'` is a global option, so denite.nvim is changing vim's behavior if it was set `'nohidden'` (on purpose or not).
I think `setlocal bufhidden=hide` is enough here.