### PR TITLE
[for Windows] Improve scantree.

### DIFF
--- a/rplugin/python3/denite/source/directory_rec.py
+++ b/rplugin/python3/denite/source/directory_rec.py
@@ -5,6 +5,8 @@
 # License: MIT license
 # ============================================================================
 
+import os
+
 from denite.source.file.rec import Source as Rec
 
 
@@ -18,21 +20,20 @@ class Source(Rec):
 
     def on_init(self, context):
         if not self.vars['command']:
-            self.vars['command'] = [
-                'find', '-L', ':directory',
-                '-path', '*/.git/*', '-prune', '-o',
-                '-type', 'l', '-print', '-o', '-type', 'd', '-print']
+            if context['is_windows']:
+                self.vars['command'] = [
+                    'scantree.py', '--type', 'd', '--path', ':directory']
+            else:
+                self.vars['command'] = [
+                    'find', '-L', ':directory',
+                    '-path', '*/.git/*', '-prune', '-o',
+                    '-type', 'l', '-print', '-o', '-type', 'd', '-print']
 
         super().on_init(context)
-
-        if context['is_windows']:
-            self.vars['command'] = []
-            self.error_message(context,
-                               'Windows environment is not supported.')
 
     def gather_candidates(self, context):
         candidates = [x for x in super().gather_candidates(context)
                       if x['action__path'] != context['__directory']]
         for candidate in candidates:
-            candidate['abbr'] = candidate['word'] + '/'
+            candidate['abbr'] = candidate['word'] + os.sep
         return candidates

--- a/rplugin/python3/denite/source/file/rec.py
+++ b/rplugin/python3/denite/source/file/rec.py
@@ -5,6 +5,7 @@
 # ============================================================================
 
 import argparse
+import itertools
 import shutil
 from sys import executable, base_exec_prefix
 from pathlib import Path
@@ -43,7 +44,7 @@ class Source(Base):
                     '-type', 'l', '-print', '-o', '-type', 'f', '-print']
             else:
                 self.vars['command'] = self.parse_command_for_scantree(
-                    ['scantree.py'])
+                    ['scantree.py', '--path', ':directory'])
 
         context['__proc'] = None
         directory = context['args'][0] if len(
@@ -141,7 +142,9 @@ class Source(Base):
         """Given the user choice for --ignore get the corresponding value"""
 
         parser = argparse.ArgumentParser(description="parse scantree options")
+        parser.add_argument('--path')
         parser.add_argument('--ignore', type=str, default=None)
+        parser.add_argument('--type', nargs='*')
 
         # the first name on the list is 'scantree.py'
         args = parser.parse_args(
@@ -153,6 +156,9 @@ class Source(Base):
 
         scantree_py = Path(__file__).parent.parent.parent.joinpath(
             'scantree.py')
+        path_args = (['--path', args.path] if args.path else [])
+        type_args = list(itertools.chain.from_iterable(
+            ('--type', t) for t in (args.type or [])))
 
         return [Source.get_python_exe(), str(scantree_py), '--ignore', ignore,
-                '--path', ':directory']
+                *path_args, *type_args]


### PR DESCRIPTION
  * Add `--type` option to scantree.py
  * Fix argument parsing in file/rec
  * Using scantree.py in directory_rec

