### PR TITLE
add check to v:version in plugin dir

### DIFF
--- a/plugin/denite.vim
+++ b/plugin/denite.vim
@@ -4,7 +4,7 @@
 " License: MIT license
 "=============================================================================
 
-if exists('g:loaded_denite')
+if exists('g:loaded_denite') && v:version < 800
   finish
 endif
 let g:loaded_denite = 1


### PR DESCRIPTION
Hello.

In this document, `denite.nvim` support Vim 8.0.0107 or above or Neovim 0.30.

Therefore, I added checking about `v:version < 800` in plugin dir.

Please check this Pull Request.