### PR TITLE
Fix issue where Default has no attribute '_filter_floating' error happens sometimes

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -47,6 +47,7 @@ class Default(object):
         self._sources_history: typing.List[typing.Any] = []
         self._previous_text = ''
         self._floating = False
+        self._filter_floating = False
         self._updated = False
         self._timers: typing.Dict[str, int] = {}
 


### PR DESCRIPTION
Sometimes after `call dein#update()`, denite prints following error and fails to call denite functions.

```
Default has no attribute '_filter_floating'  
```

This may be rare case, but this patch solved the issue at that time.

P.S.
I tried to reproduce above error, but I couldn't.