### PR TITLE
Remove encoding and unicode_errors option from Packer and Unpacker

### DIFF
--- a/rplugin/python3/denite/child.py
+++ b/rplugin/python3/denite/child.py
@@ -34,12 +34,9 @@ class Child(object):
         self._runtimepath = ''
         self._current_sources: typing.List[typing.Any] = []
         self._unpacker = msgpack.Unpacker(
-            encoding='utf-8',
             unicode_errors='surrogateescape')
         self._packer = msgpack.Packer(
-            use_bin_type=True,
-            encoding='utf-8',
-            unicode_errors='surrogateescape')
+            use_bin_type=True)
 
     def main_loop(self, stdout: typing.Any) -> None:
         while True:

--- a/rplugin/python3/denite/parent.py
+++ b/rplugin/python3/denite/parent.py
@@ -91,11 +91,8 @@ class ASyncParent(_Parent):
         self._queue_in: Queue[str] = Queue()
         self._queue_out: Queue[str] = Queue()
         self._packer = msgpack.Packer(
-            use_bin_type=True,
-            encoding='utf-8',
-            unicode_errors='surrogateescape')
+            use_bin_type=True)
         self._unpacker = msgpack.Unpacker(
-            encoding='utf-8',
             unicode_errors='surrogateescape')
 
         info = None


### PR DESCRIPTION
Same as https://github.com/Shougo/deoplete.nvim/pull/1047, Remove the encoding and unicode_errors option from msgpack.Packer, and remove the encoding option from msgpack.Unpacker.
ref:
- msgpack/msgpack-python@e1ed004
- msgpack/msgpack-python@e419cd8

---

For users: Note that I talked with @Shougo on the above pull request thread, We should wait until of msgpack-python is released a new version.
means, this pull request is for in the future.