### PR TITLE
reduce sleep() value in Process.communicate initialization

### DIFF
--- a/rplugin/python3/denite/process.py
+++ b/rplugin/python3/denite/process.py
@@ -73,7 +73,7 @@ class Process(object):
         outs = []
 
         if self._queue_out.empty():
-            sleep(0.1)
+            sleep(0.01)
         while not self._queue_out.empty() and time() < start + timeout:
             outs.append(self._queue_out.get_nowait())
 


### PR DESCRIPTION
In small directory, `:Denite file/rec` initialization is slower than `:Unite file_rec`.
Because denite call `sleep(0.1)` in Process.communicate initialization.

I think `0.1` is too much.