### PR TITLE
add '-split=floating_relative' option

### DIFF
--- a/autoload/denite/filter.vim
+++ b/autoload/denite/filter.vim
@@ -104,7 +104,15 @@ function! s:new_filter_buffer(context) abort
             \ 'width': str2nr(a:context['winwidth']),
             \ 'height': 1,
             \})
-    else
+    elseif a:context['split'] ==# 'floating_relative'
+      call nvim_open_win(bufnr('%'), v:true, {
+            \ 'relative': 'editor',
+            \ 'row': row + winheight(0),
+            \ 'col': win_screenpos(0)[1],
+            \ 'width': winwidth(0),
+            \ 'height': 1,
+            \})
+    elseif a:context['filter_split_direction'] ==# 'floating'
       call nvim_open_win(bufnr('%'), v:true, {
             \ 'relative': 'editor',
             \ 'row': row + winheight(0) + 1,


### PR DESCRIPTION
This PR adds an option for opening denite's floating window near cursor position like popup-menu.

![output](https://user-images.githubusercontent.com/47175337/76102211-fee01e80-6012-11ea-9fdd-593026e79287.gif)
`:Denite -split=floating_relative neoyank register`

Now this option doesn't work with -auto-resize option.
I will support this later.