### PR TITLE
fix -start-filter behaviour when use with -split=floating_relative

### DIFF
--- a/autoload/denite/filter.vim
+++ b/autoload/denite/filter.vim
@@ -93,6 +93,9 @@ function! s:new_filter_buffer(context) abort
     " Note: win_screenpos() == [1, 1] if start_filter
     if row <= 0
       let row = a:context['filter_winrow']
+      let on_start_filter = v:true
+    else
+      let on_start_filter = v:false
     endif
     let winrow = str2nr(a:context['winrow'])
     let wincol = str2nr(a:context['wincol'])
@@ -105,10 +108,12 @@ function! s:new_filter_buffer(context) abort
             \ 'height': 1,
             \})
     elseif a:context['split'] ==# 'floating_relative'
-      call nvim_open_win(bufnr('%'), v:true, {
-            \ 'relative': 'editor',
-            \ 'row': row + winheight(0),
-            \ 'col': win_screenpos(0)[1] - 1,
+      " cursor pos cannot be get from this function.
+      " so estimate cursor position from floating buffer position instead.
+        call nvim_open_win(bufnr('%'), v:true, {
+            \ 'relative': 'win',
+            \ 'row': on_start_filter ? row : row + winheight(0),
+            \ 'col': nvim_win_get_config(0)['col'],
             \ 'width': winwidth(0),
             \ 'height': 1,
             \})

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -330,7 +330,7 @@ class Default(object):
         command = 'edit'
         if split == 'tab':
             self._vim.command('tabnew')
-        if self._floating:
+        elif self._floating:
             # Use floating window
             if self._vim.current.buffer.options['filetype'] != 'denite':
                 self._titlestring = self._vim.options['titlestring']
@@ -353,7 +353,8 @@ class Default(object):
                 else:
                     width = int(self._context['winwidth'])
                     height = int(self._context['winheight'])
-                if opened_pos + height > self._vim.eval('&lines'):
+
+                if opened_pos + height + 3 > self._vim.eval('&lines'):
                     anchor = 'SW'
                     row = 0
                     self._context['filter_winrow'] = row + opened_pos

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -356,9 +356,11 @@ class Default(object):
                 if opened_pos + height > self._vim.eval('&lines'):
                     anchor = 'SW'
                     row = 0
+                    self._context['filter_winrow'] = row + opened_pos
                 else:
                     anchor = 'NW'
                     row = 1
+                    self._context['filter_winrow'] = row + height + opened_pos
                 self._vim.call(
                     'nvim_open_win',
                     self._vim.call('bufnr', '%'), True, {


### PR DESCRIPTION
ref. #760 

Sorry for taking your time again.
This PR fix the problem and improve behavior of -split=floating_relative.