### PR TITLE
BugFix:Fix error in command_history with auto_action='preview' option

### DIFF
--- a/rplugin/python3/denite/source/command_history.py
+++ b/rplugin/python3/denite/source/command_history.py
@@ -102,7 +102,7 @@ class Kind(Command):
 
         self.name = 'command/history'
         self.redraw_actions = 'delete'
-        self.persist_actions = 'delete'
+        self.persist_actions = ['preview','delete']
 
     def action_delete(self, context: UserContext) -> None:
         for target in sorted(context['targets'],


### PR DESCRIPTION
* Add preview to the persistant list for command_history to stop autoclosing of denit-buffer with auto_action='preview'
