### PR TITLE
Fix AttributeError caused by move_up_path action

### DIFF
--- a/rplugin/python3/denite/ui/map.py
+++ b/rplugin/python3/denite/ui/map.py
@@ -96,7 +96,7 @@ def _filter_async(denite: Default, params: Params) -> typing.Any:
 
 
 def _move_up_path(denite: Default, params: Params) -> typing.Any:
-    denite._context['path'] = Path(denite._context['path']).parent
+    denite._context['path'] = str(Path(denite._context['path']).parent)
     return denite._restart()
 
 


### PR DESCRIPTION
Since e0c8d50ebda8f2f80f56fed59891d4e201273874 4e13d5c10044f9401a51fc8ee947b28830815cd5, `move_up_path` causes error.
My pr fixes `context['path']`  type ( It seems to be string).

## Error Message

```
[denite] Traceback (most recent call last):
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\rplugin.py", line 65, in do_map
[denite]     return do_map(ui, args[1], args[2])
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\ui\map.py", line 20, in do_map
[denite]     return MAPPINGS[name](denite, params)
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\ui\map.py", line 100, in _move_up_path
[denite]     return denite._restart()
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\ui\default.py", line 150, in _restart
[denite]     self._init_denite()
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\ui\default.py", line 835, in _init_denite
[denite]     self._denite.on_init(self._context)
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\parent.py", line 50, in on_init
[denite]     self._put('on_init', [context])
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\parent.py", line 80, in _put
[denite]     return self._child.main(name, args, queue_id=0)
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\child.py", line 70, in main
[denite]     self.on_init(args[0])
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\child.py", line 160, in on_init
[denite]     source.on_init(source.context)
[denite]   File "C:\Users\ork\.cache\dein\repos\github.com\Shougo\denite.nvim\rplugin\python3\denite\source\file\rec.py", line 55, in on_init
[denite]     context['__directory'] = abspath(self.vim, directory)
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\util.py", line 162, in abspath
[denite]     return str(Path(vim.call('getcwd')).joinpath(expand(path)).resolve())
[denite]   File "C:/Users/ork/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3\denite\util.py", line 156, in expand
[denite]     if path.startswith('~'):
[denite] AttributeError: 'WindowsPath' object has no attribute 'startswith'
[denite] Please execute :messages command.
```
## Environment Information (Required!)

 * denite version (SHA1): d01c56ff3eab215c1485bd04d132b709f922de3e

 * OS: Windows 10

 * Vim/neovim version: NVIM v0.5.0-dev+1000-g84d08358b
