### PR TITLE
Fix path display of grep source

### DIFF
--- a/rplugin/python3/denite/source/grep.py
+++ b/rplugin/python3/denite/source/grep.py
@@ -150,6 +150,7 @@ class Source(Base):
             context['__proc'] = None
 
         candidates = []
+        delimiter = '\\' if context['is_windows'] else '/'
 
         for line in outs:
             result = util.parse_jump_line(context['path'], line)
@@ -157,7 +158,7 @@ class Source(Base):
                 continue
             path = (str(Path(result[0]).relative_to(context['path']))
                     if result[0] != context['path'] and
-                    result[0].startswith(context['path'] + '/')
+                    result[0].startswith(context['path'] + delimiter)
                     else context['path'])
             truncated = truncate(self.vim, path, self.vars['max_path_length'])
             candidates.append(_candidate(result, truncated))


### PR DESCRIPTION
At Windows environment, path display in grep source is strange.
File name doesn't appear.

https://gyazo.com/2b92bfbc5542f3d67b6769057e258822
![image](https://user-images.githubusercontent.com/47175337/104579990-0eeb7480-56a0-11eb-9b23-f0d68c4ed31b.png)