### PR TITLE
Document more specific

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -273,7 +273,8 @@ EXAMPLES						*denite-examples*
 	      \   'venv/', 'images/', '*.min.*', 'img/', 'fonts/'])
 
 	" Custom action
-	" Note: lambda function is not supported in Vim8.
+	" Note: denite#custom#action() with lambda parameter is only available
+	"       in NeoVim; not supported in Vim8.
 	call denite#custom#action('file', 'test',
 	      \ {context -> execute('let g:foo = 1')})
 	call denite#custom#action('file', 'test2',


### PR DESCRIPTION
lambda function itself is supported by Vim8. The problem it focuses on here is not that but just about passing it into that specific function.