### PR TITLE
fix preview_bat split direction

### DIFF
--- a/autoload/denite/helper.vim
+++ b/autoload/denite/helper.vim
@@ -79,7 +79,7 @@ function! denite#helper#preview_file(context, filename) abort
     endif
   else
     if a:filename ==# ''
-      silent rightbelow new
+      silent aboveleft new
     else
       call denite#util#execute_path('silent aboveleft pedit!', a:filename)
 


### PR DESCRIPTION
When executing `preview_bat` action, preview window appears under denite window not above it. This behaviour is different from `preview` action.

![denite_preview](https://user-images.githubusercontent.com/63794197/106898304-5d3be280-6737-11eb-89ab-565d132c8fe2.png)
