### PR TITLE
improve preview_bat window appearance

### DIFF
--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -100,10 +100,17 @@ class Kind(Openable):
         else:
             path = target['action__path'].replace('/./', '/')
 
+        bat_cmd = ['bat', '-n', path]
+        line = int(target.get('action__line', 0))
+        if line:
+            start_line = max(0, line - int(context['preview_height'] / 2))
+            bat_cmd.extend(['-r', '{}:'.format(start_line),
+                            '--highlight-line', line])
+
         if self.vim.call('has', 'nvim'):
-            self.vim.call('termopen', ['bat', path])
+            self.vim.call('termopen', bat_cmd)
         else:
-            self.vim.call('term_start', ['bat', path], {
+            self.vim.call('term_start', bat_cmd, {
                 'curwin': True,
                 'term_kill': 'kill',
             })


### PR DESCRIPTION
Improved `preview_bat` window appearance with the following changes. This will be useful for grep preview.
- When `target['action_line']` is specified, jump to the line and highlight it.
- show only line numbers. Header file name seems to be not needed.
