### PR TITLE
Fix for help preview.

### DIFF
--- a/rplugin/python3/denite/kind/openable.py
+++ b/rplugin/python3/denite/kind/openable.py
@@ -115,8 +115,9 @@ class Kind(Base):
         except Exception:
             pass
 
-        # Open folds
+        # Open folds and centering
         self.vim.command('normal! zv')
+        self.vim.command('normal! zz')
 
     def _is_current_buffer_empty(self) -> bool:
         buffer = self.vim.current.buffer

--- a/rplugin/python3/denite/source/help.py
+++ b/rplugin/python3/denite/source/help.py
@@ -38,7 +38,7 @@ class Source(Base):
                         root + sep + candidate.split("\t")[1]
                     ),
                     'action__pattern': (
-                        candidate.split("\t")[2].rstrip('\n')[1:]
+                        r'\V' + candidate.split("\t")[2].rstrip('\n')[1:]
                     ),
                 }, ins)))
         return candidates


### PR DESCRIPTION
Thanks for merging and fixing #836.
Additional changes for preview action.
- Append '\V' to `action__pattern` to treat '*' and other special characters in tag literally.
- Do `normal! zz` to ensure that the cursor line is always centered. `cursor()` does not center line when the line to jump is already in the screen.
