### PR TITLE
Don't close nolisted and shown buffer when quitting denite window.

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -774,7 +774,11 @@ class Default(object):
         # Clear previewed buffers
         prev_bufnr = self._vim.call('bufnr', '%')
         for bufnr in self._vim.vars['denite#_previewed_buffers'].keys():
-            self._vim.command('silent bdelete! ' + str(bufnr))
+            # don't close nolisted and shown buffer
+            if self._vim.call('win_findbuf', int(bufnr)):
+                self._vim.call('setbufvar', int(bufnr), '&buflisted', 0)
+            else:
+                self._vim.command('silent bdelete! ' + str(bufnr))
         self._vim.vars['denite#_previewed_buffers'] = {}
         if self._vim.call('bufnr', '%') != prev_bufnr:
             # Restore buffer


### PR DESCRIPTION
## Problem summary
When quitting denite window after previewing files, windows which contain nolisted buffer are also closed.
## Reproduce way
1. Open (Neo)Vim.
1. `:h`
1. `:Denite help -input=helptxt`
1. Execute `preview` action.
1. Quit denite window, and you will see existing help window is closed.
## Solution
If there are buffers which are not listed but shown, denite should only make them `nobuflisted` not delete the buffer. This will restore the state before starting denite.