### PR TITLE
Close opening preview_bat window.

### DIFF
--- a/autoload/denite/init.vim
+++ b/autoload/denite/init.vim
@@ -81,6 +81,7 @@ endfunction
 function! s:initialize_variables() abort
   let g:denite#_filter_winid = -1
   let g:denite#_previewed_buffers = {}
+  let g:denite#_previewing_bufnr = -1
   let g:denite#_candidates = []
   let g:denite#_ret = {}
   let g:denite#_async_ret = {}

--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -101,6 +101,7 @@ class Kind(Openable):
                     self._remove_previewed_buffer(
                             self.vim.call('bufnr', '%'))
                 self.vim.command('close!')
+                self.vim.vars['denite#_previewing_bufnr'] = -1
             self.vim.call('win_gotoid', prev_id)
             self._previewed_winid = 0
 
@@ -130,8 +131,10 @@ class Kind(Openable):
                 'term_kill': 'kill',
             })
 
-        self._add_previewed_buffer(self.vim.call('bufnr', '%'))
+        bufnr = self.vim.call('bufnr', '%')
+        self._add_previewed_buffer(bufnr)
         self._previewed_winid = self.vim.call('win_getid')
+        self._vim.vars['denite#_previewing_bufnr'] = bufnr
 
         self.vim.call('win_gotoid', prev_id)
         self._previewed_target = target

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -265,6 +265,7 @@ class Default(object):
         self._bufvars['denite_statusline'] = {}
 
         self._vim.vars['denite#_previewed_buffers'] = {}
+        self._vim.vars['denite#_previewing_bufnr'] = -1
 
         self._save_window_options = {}
         window_options = {
@@ -775,11 +776,13 @@ class Default(object):
         prev_bufnr = self._vim.call('bufnr', '%')
         for bufnr in [
                 x for x in self._vim.vars['denite#_previewed_buffers'].keys()
-                if not self._vim.call('win_findbuf', int(x))
+                if (int(x) == self._vim.vars['denite#_previewing_bufnr'] or
+                    not self._vim.call('win_findbuf', int(x)))
         ]:
             # Note: Don't close shown buffer
             self._vim.command('silent bdelete! ' + str(bufnr))
         self._vim.vars['denite#_previewed_buffers'] = {}
+        self._vim.vars['denite#_previewing_bufnr'] = -1
         if self._vim.call('bufnr', '%') != prev_bufnr:
             # Restore buffer
             self._vim.command('buffer ' + str(prev_bufnr))


### PR DESCRIPTION
When quitting denite window while preview_bat window is shown, the preview window is not closed. This was caused by #839.