### PR TITLE
Don't save preview_bat output.

### DIFF
--- a/rplugin/python3/denite/kind/file.py
+++ b/rplugin/python3/denite/kind/file.py
@@ -96,11 +96,7 @@ class Kind(Openable):
         if self._previewed_winid:
             self.vim.call('win_gotoid', self._previewed_winid)
             if self.vim.call('win_getid') != prev_id:
-                # in Neovim :close! deletes terminal buffer if 'nohidden'
-                if is_nvim and not self.vim.options['hidden']:
-                    self._remove_previewed_buffer(
-                            self.vim.call('bufnr', '%'))
-                self.vim.command('close!')
+                self.vim.command('bdelete! ' + self.vim.call('bufnr', '%'))
                 self.vim.vars['denite#_previewing_bufnr'] = -1
             self.vim.call('win_gotoid', prev_id)
             self._previewed_winid = 0
@@ -132,7 +128,6 @@ class Kind(Openable):
             })
 
         bufnr = self.vim.call('bufnr', '%')
-        self._add_previewed_buffer(bufnr)
         self._previewed_winid = self.vim.call('win_getid')
         self._vim.vars['denite#_previewing_bufnr'] = bufnr
 

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -772,12 +772,15 @@ class Default(object):
         if not self._context['has_preview_window']:
             self._vim.command('pclose!')
 
+        bat_bufnr = self._vim.vars['denite#_previewing_bufnr']
+        if bat_bufnr != -1:
+            self._vim.command('bdelete! ' + bat_bufnr)
+
         # Clear previewed buffers
         prev_bufnr = self._vim.call('bufnr', '%')
         for bufnr in [
                 x for x in self._vim.vars['denite#_previewed_buffers'].keys()
-                if (int(x) == self._vim.vars['denite#_previewing_bufnr'] or
-                    not self._vim.call('win_findbuf', int(x)))
+                if not self._vim.call('win_findbuf', int(x))
         ]:
             # Note: Don't close shown buffer
             self._vim.command('silent bdelete! ' + str(bufnr))


### PR DESCRIPTION
Buffers that `preview_bat` action makes cannot be reused and remaining bat buffers increase RAM usage. Deleting preview_bat buffer each time will save RAM usage and make implimentation simpler. In paticular, this would be useful for `-auto-action=preview_bat`.
