### PR TITLE
Fix removing autocmd

### DIFF
--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -179,8 +179,6 @@ class Default(object):
                context: UserContext) -> None:
         from denite.ui.map import do_map
 
-        self._vim.command('silent! autocmd! denite <buffer>')
-
         if re.search(r'\[Command Line\]$', self._vim.current.buffer.name):
             # Ignore command line window.
             return
@@ -330,6 +328,8 @@ class Default(object):
         if not self._vim.call('has', 'nvim'):
             # In Vim8, FileType autocmd is not fired after set filetype option.
             self._vim.command('silent doautocmd FileType denite')
+
+        self._vim.command('silent! autocmd! denite CursorMoved <buffer>')
 
         if self._context['auto_action']:
             self._vim.command('autocmd denite '


### PR DESCRIPTION
## Problem
CursorMoved autocmd for auto-action isn't removed when opening the denite buffer of the same source. This slows denite when `auto-action` is specified.
## Cause
[This line](https://github.com/Shougo/denite.nvim/blob/8c44de41ec46c44f84dd70907a5763112df2eacb/rplugin/python3/denite/ui/default.py#L182) does not work because of these reasons.
- `autocmd! <buffer>` must be called with autocmd-event name.
- This command is called before entering denite buffer

