### PR TITLE
Add toggle-auto-action mapping

### DIFF
--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -412,6 +412,12 @@ restore_sources
 		Move back to the previous sources.
 		Note: It does not restore the cursor position.
 
+						*denite-map-toggle_auto_action*
+toggle_auto_action:{action}
+		Change |denite-option-auto-action| to {action}.
+		If |denite-option-auto-action| is {action}, it will be disabled.
+		If {action} is empty, all auto actions are disabled.
+
 						*denite-map-toggle_select*
 toggle_select
 		Toggle cursor candidate select.

--- a/rplugin/python3/denite/ui/default.py
+++ b/rplugin/python3/denite/ui/default.py
@@ -768,12 +768,8 @@ class Default(object):
 
         # Note: Close filter window before preview window
         self._vim.call('denite#filter#_close_filter_window')
-        if not self._context['has_preview_window']:
-            self._vim.command('pclose!')
 
-        bat_bufnr = self._vim.vars['denite#_previewing_bufnr']
-        if bat_bufnr != -1:
-            self._vim.command('bdelete! ' + str(bat_bufnr))
+        self._close_previewing_window()
 
         # Clear previewed buffers
         prev_bufnr = self._vim.call('bufnr', '%')
@@ -793,6 +789,15 @@ class Default(object):
         if self._floating or self._filter_floating:
             self._vim.options['titlestring'] = self._titlestring
             self._vim.options['ruler'] = self._ruler
+
+    def _close_previewing_window(self) -> None:
+        if not self._context['has_preview_window']:
+            self._vim.command('pclose!')
+
+        bat_bufnr = self._vim.vars['denite#_previewing_bufnr']
+        if bat_bufnr != -1:
+            self._vim.command('bdelete! ' + str(bat_bufnr))
+            self._vim.vars['denite#_previewing_bufnr'] = -1
 
     def _close_current_window(self) -> None:
         if self._vim.call('winnr', '$') == 1:

--- a/rplugin/python3/denite/ui/map.py
+++ b/rplugin/python3/denite/ui/map.py
@@ -228,6 +228,26 @@ def _restore_sources(denite: Default, params: Params) -> typing.Any:
     denite._start_sources_queue(denite._context)
 
 
+def _toggle_auto_action(denite: Default, params: Params) -> None:
+    name = params[0] if params else ''
+    context = denite._context
+
+    denite._vim.command('silent! autocmd! denite CursorMoved <buffer>')
+    denite._close_previewing_window()
+
+    if context['auto_action'] != name:
+        context['auto_action'] = name
+    else:
+        context['auto_action'] = ''
+
+    _auto_action(denite, params)
+
+    if denite._context['auto_action']:
+        denite._vim.command('autocmd denite '
+                            'CursorMoved <buffer> '
+                            'call denite#call_map("auto_action")')
+
+
 def _toggle_matchers(denite: Default, params: Params) -> typing.Any:
     matchers = ''.join(params)
     context = denite._context
@@ -293,6 +313,7 @@ MAPPINGS: typing.Dict[str, Action] = {
     'redraw': _redraw,
     'restart': _restart,
     'restore_sources': _restore_sources,
+    'toggle_auto_action': _toggle_auto_action,
     'toggle_matchers': _toggle_matchers,
     'toggle_select': _toggle_select,
     'toggle_select_all': _toggle_select_all,


### PR DESCRIPTION
`auto_action` feature is useful, but sometimes previewing slow denite and it can be annoying.
It would be very useful if auto_action can be toggled without restarting denite.
