### PR TITLE
Fix matcher/matchfuzzy not working

### DIFF
--- a/rplugin/python3/denite/filter/matcher/matchfuzzy.py
+++ b/rplugin/python3/denite/filter/matcher/matchfuzzy.py
@@ -26,7 +26,7 @@ class Filter(Base):
 
         return list(self.vim.call(
                         'matchfuzzy', context['candidates'],
-                        context['complete_str'], {'key': 'word'}
+                        context['input'], {'key': 'word'}
                 ))
 
     def convert_pattern(self, input_str: str) -> str:


### PR DESCRIPTION
matcher/matchfuzzy throws errors on Vim8.
I think `'input'` is correct here, isn't it?