### PR TITLE
旧オプションfloating_relativeを消す

### DIFF
--- a/autoload/denite/filter.vim
+++ b/autoload/denite/filter.vim
@@ -103,72 +103,79 @@ endfunction
 
 function! s:new_filter_buffer(context) abort
   if denite#util#check_floating(a:context)
-    let row = win_screenpos(win_getid())[0] - 1
-    " Note: win_screenpos() == [1, 1] if start_filter
-    if row <= 0
-      let row = a:context['filter_winrow']
-      let on_start_filter = v:true
-    else
-      let on_start_filter = v:false
-    endif
-    let floating_border = a:context['floating_border'] !=# ''
-          \ && has('nvim-0.5')
-    let winrow = a:context['winrow']
-    let wincol = a:context['wincol']
-    if a:context['split'] ==# 'floating'
-      let args = {
-            \ 'relative': 'editor',
-            \ 'row': winrow == 1 ? 0 : row + winheight(0) +
-            \        (floating_border ? 1 : 0),
-            \ 'col': wincol,
-            \ 'width': a:context['winwidth'],
-            \ 'height': 1,
-            \}
-      if floating_border
-        let args['border'] = a:context['floating_border']
-      endif
-      call nvim_open_win(bufnr('%'), v:true, args)
-    elseif a:context['split'] ==# 'floating_relative_cursor'
-          \ || a:context['split'] ==# 'floating_relative_window'
-      " cursor position cannot be gotten from this function.
-      " so instead estimating it from floating buffer position.
-      let args = {
-            \ 'relative': 'editor',
-            \ 'row': on_start_filter ? row : row + winheight(0) +
-            \        (floating_border ? 1 : 0),
-            \ 'col': on_start_filter ? nvim_win_get_config(0)['col']
-            \ : win_screenpos(0)[1] - 1,
-            \ 'width': winwidth(0),
-            \ 'height': 1,
-            \}
-      if floating_border
-        let args['border'] = a:context['floating_border']
-      endif
-      call nvim_open_win(bufnr('%'), v:true, args)
-    elseif a:context['filter_split_direction'] ==# 'floating'
-      let args = {
-            \ 'relative': 'editor',
-            \ 'row': row + winheight(0) + 1,
-            \ 'col': win_screenpos(0)[1] - 1,
-            \ 'width': winwidth(0),
-            \ 'height': 1,
-            \}
-      if floating_border
-        let args['border'] = a:context['floating_border']
-      endif
-      call nvim_open_win(bufnr('%'), v:true, args)
-    endif
-    if exists('*bufadd')
-      let bufnr = bufadd('denite-filter')
-      execute bufnr 'buffer'
-    else
-      silent edit denite-filter
-    endif
-    let &l:winhighlight = 'Normal:' . a:context['highlight_filter_background']
+    call s:new_floating_filter_buffer(a:context)
   else
     silent execute a:context['filter_split_direction'] 'split' 'denite-filter'
+    let g:denite#_filter_winid = win_getid()
+    let g:denite#_filter_bufnr = bufnr('%')
   endif
 
+endfunction
+
+function s:new_floating_filter_buffer(context) abort
+  let row = win_screenpos(win_getid())[0] - 1
+  " Note: win_screenpos() == [1, 1] if start_filter
+  if row <= 0
+    let row = a:context['filter_winrow']
+    let on_start_filter = v:true
+  else
+    let on_start_filter = v:false
+  endif
+  let floating_border = a:context['floating_border'] !=# '' && has('nvim-0.5')
+  let winrow = a:context['winrow']
+  let wincol = a:context['wincol']
+  if a:context['split'] ==# 'floating'
+    let args = {
+          \ 'relative': 'editor',
+          \ 'row': winrow == 1 ? 0 : row + winheight(0) +
+          \        (floating_border ? 1 : 0),
+          \ 'col': wincol,
+          \ 'width': a:context['winwidth'],
+          \ 'height': 1,
+          \}
+    if floating_border
+      let args['border'] = a:context['floating_border']
+    endif
+    call nvim_open_win(bufnr('%'), v:true, args)
+  elseif a:context['split'] ==# 'floating_relative_cursor'
+        \ || a:context['split'] ==# 'floating_relative_window'
+    " cursor position cannot be gotten from this function.
+    " so instead estimating it from floating buffer position.
+    let args = {
+          \ 'relative': 'editor',
+          \ 'row': on_start_filter ? row : row + winheight(0) +
+          \        (floating_border ? 1 : 0),
+          \ 'col': on_start_filter ? nvim_win_get_config(0)['col']
+          \ : win_screenpos(0)[1] - 1,
+          \ 'width': winwidth(0),
+          \ 'height': 1,
+          \}
+    if floating_border
+      let args['border'] = a:context['floating_border']
+    endif
+    call nvim_open_win(bufnr('%'), v:true, args)
+  elseif a:context['filter_split_direction'] ==# 'floating'
+    let args = {
+          \ 'relative': 'editor',
+          \ 'row': row + winheight(0) + 1,
+          \ 'col': win_screenpos(0)[1] - 1,
+          \ 'width': winwidth(0),
+          \ 'height': 1,
+          \}
+    if floating_border
+      let args['border'] = a:context['floating_border']
+    endif
+    call nvim_open_win(bufnr('%'), v:true, args)
+  endif
+
+  if exists('*bufadd')
+    let bufnr = bufadd('denite-filter')
+    execute bufnr 'buffer'
+  else
+    silent edit denite-filter
+  endif
+
+  let &l:winhighlight = 'Normal:' . a:context['highlight_filter_background']
   let g:denite#_filter_winid = win_getid()
   let g:denite#_filter_bufnr = bufnr('%')
 endfunction

--- a/autoload/denite/util.vim
+++ b/autoload/denite/util.vim
@@ -267,7 +267,8 @@ endfunction
 
 function! denite#util#check_floating(context) abort
   return (a:context['split'] ==# 'floating' ||
-        \ a:context['split'] ==# 'floating_relative' ||
+        \ a:context['split'] ==# 'floating_relative_cursor' ||
+        \ a:context['split'] ==# 'floating_relative_window' ||
         \ a:context['filter_split_direction'] ==# 'floating')
         \ && exists('*nvim_open_win')
 endfunction

--- a/doc/denite.txt
+++ b/doc/denite.txt
@@ -1007,7 +1007,8 @@ OPTIONS							*denite-options*
 -winheight={window-height}
 		Set the height of the Denite window if |denite-option-split|
 		is "horizontal".
-		if |denite-option-split| is "floating" or "floating_relative",
+		if |denite-option-split| is "floating" or
+		"floating_relative_cursor" or "floating_relative_window",
 		set the height of the floating window.
 		If auto-resize is set, |denite-option-winheight| is the
 		maximum size of the window.
@@ -1026,7 +1027,8 @@ OPTIONS							*denite-options*
 -winwidth={window-width}
 		Set the width of the Denite window if |denite-option-split|
 		is "vertical".
-		if |denite-option-split| is "floating" or "floating_relative",
+		if |denite-option-split| is "floating" or
+		"floating_relative_cursor" or "floating_relative_window",
 		set the width of the floating window.
 
 		Default: &columns / 2


### PR DESCRIPTION

ドキュメントと`denite#util#check_floating`の条件をアップデートし、
`-split=floating_relative_*`でfilter bufferが`-split=floating`と同じようにdenite bufferのすぐ下に表示されるようになった。ご確認お願いします。
