### PR TITLE
Add support denite#util#open in wsl

### DIFF
--- a/autoload/denite/util.vim
+++ b/autoload/denite/util.vim
@@ -13,6 +13,7 @@ function! s:check_wsl() abort
   if has('unix') && executable('uname')
     return match(system('uname -r'), "\\cMicrosoft") >= 0
   endif
+  return v:false
 endfunction
 
 let s:is_wsl = s:check_wsl()


### PR DESCRIPTION
# Problems summary

`denite#util#open` is not supported in WSL

## Expected

Open URL in default browser of Windows Host.

## Environment Information (Required!)

 * denite version (SHA1): 4e7eec5

 * OS: Ubuntu 20.04.3 LTS in Windows 10 (WSL)

 * Vim/neovim version:
   * vim: 8.2.1-3575
   * nvim: v0.5.1

 * `:checkhealth` or `:CheckHealth` result(neovim only):

## Provide a minimal init.vim with less than 50 lines (Required!)

```vim
" Your minimal init.vim
set runtimepath+=~/path/to/denite.nvim/
```

# Solution

Try to open the same way of Windows when running in WSL and cmd.exe is available